### PR TITLE
chore: get local setup working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,12 @@ One Time Setup
   # Set up a virtualenv using virtualenvwrapper with the same name as the repo and activate it
   mkvirtualenv -p python3.8 edx-exams
 
+  # Install/update the dev requirements
+  make requirements
+
+  # Run edx-exams locally
+  python manage.py runserver localhost:18740 --settings=edx_exams.settings.local
+
 
 Every time you develop something in this repo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -242,7 +242,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.txt
 pkginfo==1.8.2
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.1
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
## Description

There is a bug in pip-tools 6.6.0 that prevents a pip-sync.

This PR bumps the version of pip-tools manually so users without the pip-tools fix will not experience an error when they first try to develop.

## Testing Instructions

Tested on local after a virtualenvwrapper `wipeenv`.