### PR TITLE
feat: add API docs

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -31,6 +31,8 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'release_util',
+    'drf_yasg',
+    'edx_api_doc_tools',
 )
 
 THIRD_PARTY_APPS = (

--- a/edx_exams/urls.py
+++ b/edx_exams/urls.py
@@ -21,7 +21,7 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from rest_framework_swagger.views import get_swagger_view
+from edx_api_doc_tools import make_api_info, make_docs_urls
 
 from edx_exams.apps.api import urls as api_urls
 from edx_exams.apps.core import views as core_views
@@ -31,10 +31,9 @@ admin.autodiscover()
 urlpatterns = oauth2_urlpatterns + [
     url(r'^admin/', admin.site.urls),
     url(r'^api/', include(api_urls)),
-    url(r'^api-docs/', get_swagger_view(title='edx-exams API')),
     url(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
     url(r'', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
-    url(r'^health/$', core_views.health, name='health'),
+    url(r'^health/$', core_views.Health.as_view(), name='health'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
@@ -42,3 +41,14 @@ if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma:
     # for CI build
     import debug_toolbar  # pylint: disable=import-error
     urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))
+
+api_info = make_api_info(
+    title="edX Exams API",
+    version="v0",
+    description="A REST API for interacting with the edX exams service."
+)
+
+urlpatterns += make_docs_urls(
+    api_info,
+    api_url_patterns=[url(r'^health/$', core_views.Health.as_view(), name='health'), url(r'^api/', include(api_urls))]
+)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,6 +7,7 @@ django-extensions
 django-rest-swagger
 django-waffle
 djangorestframework
+edx-api-doc-tools
 edx-auth-backends
 edx-django-utils
 edx-django-release-util

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via django
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via requests
 cffi==1.15.0
     # via
@@ -19,9 +19,12 @@ click==8.1.3
 coreapi==2.3.3
     # via
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
-    # via coreapi
+    # via
+    #   coreapi
+    #   drf-yasg
 cryptography==37.0.2
     # via
     #   pyjwt
@@ -39,11 +42,13 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/base.in
 django-crum==0.7.9
     # via edx-django-utils
@@ -61,14 +66,20 @@ djangorestframework==3.13.1
     #   -r requirements/base.in
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via edx-drf-extensions
+drf-yasg==1.20.0
+    # via edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/base.in
 edx-auth-backends==4.1.0
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
@@ -83,6 +94,8 @@ future==0.18.2
     # via pyjwkest
 idna==3.3
     # via requests
+inflection==0.5.1
+    # via drf-yasg
 itypes==1.2.0
     # via coreapi
 jinja2==3.1.2
@@ -99,9 +112,11 @@ oauthlib==3.2.0
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
+packaging==21.3
+    # via drf-yasg
 pbr==5.9.0
     # via stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -109,7 +124,7 @@ pycryptodomex==3.14.1
     # via pyjwkest
 pyjwkest==1.4.2
     # via edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   drf-jwt
     #   edx-auth-backends
@@ -120,6 +135,8 @@ pymongo==3.12.3
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
+pyparsing==3.0.9
+    # via packaging
 python-dateutil==2.8.2
     # via edx-drf-extensions
 python3-openid==3.2.0
@@ -142,7 +159,11 @@ requests==2.27.1
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
+semantic-version==2.10.0
     # via edx-drf-extensions
 simplejson==3.17.6
     # via django-rest-swagger
@@ -168,6 +189,8 @@ stevedore==3.5.0
     #   edx-django-utils
     #   edx-opaque-keys
 uritemplate==4.1.1
-    # via coreapi
+    # via
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/validation.txt
     #   django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -21,7 +21,7 @@ bleach==5.0.0
     # via
     #   -r requirements/validation.txt
     #   readme-renderer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/validation.txt
     #   requests
@@ -61,12 +61,14 @@ coreapi==2.3.3
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/validation.txt
     #   coreapi
-coverage[toml]==6.3.2
+    #   drf-yasg
+coverage[toml]==6.4
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
@@ -82,7 +84,7 @@ defusedxml==0.7.1
     #   social-auth-core
 diff-cover==6.5.0
     # via -r requirements/dev.in
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -99,12 +101,14 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-i18n-tools
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
@@ -128,6 +132,8 @@ djangorestframework==3.13.1
     #   -r requirements/validation.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 docutils==0.18.1
     # via
@@ -137,11 +143,17 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/validation.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/validation.txt
 edx-auth-backends==4.1.0
     # via -r requirements/validation.txt
 edx-django-release-util==1.2.0
     # via -r requirements/validation.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -158,7 +170,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
     # via -r requirements/validation.txt
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -171,11 +183,15 @@ idna==3.3
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -r requirements/validation.txt
     #   keyring
     #   twine
+inflection==0.5.1
+    # via
+    #   -r requirements/validation.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via
     #   -r requirements/validation.txt
@@ -194,7 +210,7 @@ jinja2==3.1.2
     #   code-annotations
     #   coreschema
     #   diff-cover
-keyring==23.5.0
+keyring==23.5.1
     # via
     #   -r requirements/validation.txt
     #   twine
@@ -230,6 +246,7 @@ openapi-codec==1.3.2
 packaging==21.3
     # via
     #   -r requirements/validation.txt
+    #   drf-yasg
     #   pytest
     #   tox
 path==16.4.0
@@ -242,7 +259,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pip-tools==6.6.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
 pkginfo==1.8.2
     # via
@@ -261,7 +278,7 @@ pluggy==1.0.0
     #   tox
 polib==1.1.1
     # via edx-i18n-tools
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
@@ -292,7 +309,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/validation.txt
     #   drf-jwt
@@ -300,7 +317,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -328,7 +345,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/validation.txt
     #   edx-django-utils
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/validation.txt
     #   packaging
@@ -392,11 +409,19 @@ rfc3986==2.0.0
     # via
     #   -r requirements/validation.txt
     #   twine
-rich==12.3.0
+rich==12.4.4
     # via
     #   -r requirements/validation.txt
     #   twine
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/validation.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/validation.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
@@ -470,11 +495,11 @@ typing-extensions==4.2.0
     #   -r requirements/validation.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/validation.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,11 +6,11 @@
 #
 alabaster==0.7.12
     # via sphinx
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -23,9 +23,9 @@ babel==2.10.1
     # via sphinx
 bleach==5.0.0
     # via readme-renderer
-build==0.7.0
+build==0.8.0
     # via -r requirements/doc.in
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -59,12 +59,14 @@ coreapi==2.3.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.3.2
+    #   drf-yasg
+coverage[toml]==6.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -78,7 +80,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -95,11 +97,13 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -121,8 +125,10 @@ djangorestframework==3.13.1
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
-doc8==0.11.1
+doc8==0.11.2
     # via -r requirements/doc.in
 docutils==0.17.1
     # via
@@ -134,11 +140,17 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -155,7 +167,7 @@ edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -170,11 +182,15 @@ idna==3.3
     #   requests
 imagesize==1.3.0
     # via sphinx
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   keyring
     #   sphinx
     #   twine
+inflection==0.5.1
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -193,7 +209,7 @@ jinja2==3.1.2
     #   code-annotations
     #   coreschema
     #   sphinx
-keyring==23.5.0
+keyring==23.5.1
     # via twine
 lazy-object-proxy==1.7.1
     # via
@@ -228,6 +244,7 @@ packaging==21.3
     # via
     #   -r requirements/test.txt
     #   build
+    #   drf-yasg
     #   pytest
     #   sphinx
     #   tox
@@ -249,7 +266,7 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -276,7 +293,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -284,7 +301,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -312,7 +329,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
@@ -373,9 +390,17 @@ restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==12.3.0
+rich==12.4.4
     # via twine
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/test.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -464,11 +489,11 @@ typing-extensions==4.2.0
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/test.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.3
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.1
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -29,11 +29,13 @@ coreapi==2.3.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 cryptography==37.0.2
     # via
     #   -r requirements/base.txt
@@ -52,11 +54,13 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -76,16 +80,24 @@ djangorestframework==3.13.1
     #   -r requirements/base.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -112,6 +124,10 @@ idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 itypes==1.2.0
     # via
     #   -r requirements/base.txt
@@ -141,11 +157,15 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+packaging==21.3
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 pbr==5.9.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -161,7 +181,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -177,6 +197,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
+pyparsing==3.0.9
+    # via
+    #   -r requirements/base.txt
+    #   packaging
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
@@ -211,7 +235,15 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/base.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -254,6 +286,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/base.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -19,7 +19,7 @@ attrs==21.4.0
     #   pytest
 bleach==5.0.0
     # via readme-renderer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/test.txt
     #   requests
@@ -53,12 +53,14 @@ coreapi==2.3.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.3.2
+    #   drf-yasg
+coverage[toml]==6.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -72,7 +74,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -89,11 +91,13 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -115,6 +119,8 @@ djangorestframework==3.13.1
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 docutils==0.18.1
     # via readme-renderer
@@ -122,11 +128,17 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -143,7 +155,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -156,10 +168,14 @@ idna==3.3
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   keyring
     #   twine
+inflection==0.5.1
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -178,7 +194,7 @@ jinja2==3.1.2
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-keyring==23.5.0
+keyring==23.5.1
     # via twine
 lazy-object-proxy==1.7.1
     # via
@@ -212,6 +228,7 @@ openapi-codec==1.3.2
 packaging==21.3
     # via
     #   -r requirements/test.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.9.0
@@ -230,7 +247,7 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -259,7 +276,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/test.txt
     #   drf-jwt
@@ -267,7 +284,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -295,7 +312,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/test.txt
     #   packaging
@@ -352,9 +369,17 @@ requests-toolbelt==0.9.1
     # via twine
 rfc3986==2.0.0
     # via twine
-rich==12.3.0
+rich==12.4.4
     # via twine
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/test.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
@@ -423,11 +448,11 @@ typing-extensions==4.2.0
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,17 +4,17 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   pylint
     #   pylint-celery
 attrs==21.4.0
     # via pytest
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/base.txt
     #   requests
@@ -44,12 +44,14 @@ coreapi==2.3.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==6.3.2
+    #   drf-yasg
+coverage[toml]==6.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -63,7 +65,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-dill==0.3.4
+dill==0.3.5.1
     # via pylint
 distlib==0.3.4
     # via virtualenv
@@ -74,11 +76,13 @@ distlib==0.3.4
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -100,16 +104,24 @@ djangorestframework==3.13.1
     #   -r requirements/base.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via -r requirements/base.txt
 edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -124,7 +136,7 @@ edx-opaque-keys==2.3.0
     #   edx-drf-extensions
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   tox
     #   virtualenv
@@ -136,6 +148,10 @@ idna==3.3
     # via
     #   -r requirements/base.txt
     #   requests
+inflection==0.5.1
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via pytest
 isort==5.10.1
@@ -176,6 +192,8 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 packaging==21.3
     # via
+    #   -r requirements/base.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.9.0
@@ -190,7 +208,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -210,7 +228,7 @@ pyjwkest==1.4.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/base.txt
     #   drf-jwt
@@ -218,7 +236,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   edx-lint
     #   pylint-celery
@@ -240,8 +258,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pyparsing==3.0.8
-    # via packaging
+pyparsing==3.0.9
+    # via
+    #   -r requirements/base.txt
+    #   packaging
 pytest==7.1.2
     # via
     #   pytest-cov
@@ -284,7 +304,15 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/base.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/base.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
@@ -346,6 +374,7 @@ uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/base.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -4,12 +4,12 @@
 #
 #    make upgrade
 #
-asgiref==3.5.1
+asgiref==3.5.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.11.4
+astroid==2.11.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -24,7 +24,7 @@ bleach==5.0.0
     # via
     #   -r requirements/quality.txt
     #   readme-renderer
-certifi==2021.10.8
+certifi==2022.5.18.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -67,13 +67,15 @@ coreapi==2.3.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django-rest-swagger
+    #   drf-yasg
     #   openapi-codec
 coreschema==0.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==6.3.2
+    #   drf-yasg
+coverage[toml]==6.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -90,7 +92,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-dill==0.3.4
+dill==0.3.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -109,11 +111,13 @@ django==3.2.13
     #   django-extensions
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-django-utils
     #   edx-drf-extensions
-django-cors-headers==3.11.0
+django-cors-headers==3.12.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -146,6 +150,8 @@ djangorestframework==3.13.1
     #   -r requirements/test.txt
     #   django-rest-swagger
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 docutils==0.18.1
     # via
@@ -156,6 +162,15 @@ drf-jwt==1.19.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.20.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.6.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-auth-backends==4.1.0
     # via
     #   -r requirements/quality.txt
@@ -164,7 +179,7 @@ edx-django-release-util==1.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-django-utils==4.7.0
+edx-django-utils==5.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -187,7 +202,7 @@ edx-rest-api-client==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-filelock==3.6.0
+filelock==3.7.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -203,11 +218,16 @@ idna==3.3
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==4.11.3
+importlib-metadata==4.11.4
     # via
     #   -r requirements/quality.txt
     #   keyring
     #   twine
+inflection==0.5.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==1.1.1
     # via
     #   -r requirements/quality.txt
@@ -229,7 +249,7 @@ jinja2==3.1.2
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-keyring==23.5.0
+keyring==23.5.1
     # via
     #   -r requirements/quality.txt
     #   twine
@@ -276,6 +296,7 @@ packaging==21.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   drf-yasg
     #   pytest
     #   tox
 pbr==5.9.0
@@ -299,7 +320,7 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.0
+psutil==5.9.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -334,7 +355,7 @@ pyjwkest==1.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-pyjwt[crypto]==2.3.0
+pyjwt[crypto]==2.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -343,7 +364,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.8
+pylint==2.13.9
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -377,7 +398,7 @@ pynacl==1.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-django-utils
-pyparsing==3.0.8
+pyparsing==3.0.9
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -453,11 +474,21 @@ rfc3986==2.0.0
     # via
     #   -r requirements/quality.txt
     #   twine
-rich==12.3.0
+rich==12.4.4
     # via
     #   -r requirements/quality.txt
     #   twine
-semantic-version==2.9.0
+ruamel-yaml==0.17.21
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.6
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   ruamel-yaml
+semantic-version==2.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -542,12 +573,12 @@ typing-extensions==4.2.0
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-    #   rich
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   coreapi
+    #   drf-yasg
 urllib3==1.26.9
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
## [MST-1445](https://2u-internal.atlassian.net/browse/MST-1445)

Add api docs for edx-exams. In order for the health endpoint to be listed, I had to convert it to an API View. This might be a little hacky, so we could leave it as is and just have the API docs be empty for now. 

<img width="1415" alt="Screen Shot 2022-05-27 at 11 29 05 AM" src="https://user-images.githubusercontent.com/46360176/170732853-4ac8d91b-2dc2-4039-9cba-a4bc6fd7065f.png">

<img width="1402" alt="Screen Shot 2022-05-27 at 11 29 12 AM" src="https://user-images.githubusercontent.com/46360176/170732898-83ecdbd6-1c83-4f08-978c-b67266c5777a.png">

