### PR TITLE
fix: update settings to remove warnings

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -119,6 +119,7 @@ LOCALE_PATHS = (
     root('conf', 'locale'),
 )
 
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # MEDIA CONFIGURATION
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-root
@@ -156,6 +157,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
+                'django.template.context_processors.request',
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',


### PR DESCRIPTION
There are two warnings that currently appear when running migrations for edx-exams: 

`?: (admin.W411) 'django.template.context_processors.request' must be enabled in DjangoTemplates (TEMPLATES) in order to use the admin navigation sidebar.`

`core.User: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.`

These changes will fix those warnings.