### PR TITLE
feat: add PR template and fix other github actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+**JIRA:** Link to JIRA ticket
+
+**Description:** Describe in a couple of sentences what this PR adds
+
+**Author concerns:** List any concerns about this PR - inelegant 
+solutions, hacks, quick-and-dirty implementations, concerns about 
+migrations, etc.
+
+**Dependencies:** dependencies on other outstanding PRs, issues, etc. 
+
+**Installation instructions:** List any non-trivial installation 
+instructions.
+
+**Testing instructions:**
+
+1. Open page A
+2. Do thing B
+3. Expect C to happen
+4. If D happened instead - check failed.
+
+**Merge checklist:**
+- [ ] All reviewers approved
+- [ ] CI build is green
+- [ ] Changelog record added
+- [ ] Documentation updated (not only docstrings)
+- [ ] Commits are squashed
+
+**Post merge:**
+- [ ] Delete working branch (if not needed anymore)

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,13 +8,13 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: 'master'
+        default: 'main'
 
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: edx/.github/.github/workflows/upgrade-python-requirements.yml@master
     with:
-      branch: ${{ github.event.inputs.branch || 'master' }}
+      branch: ${{ github.event.inputs.branch || 'main' }}
       # optional parameters below; fill in if you'd like github or email notifications
       # user_reviewers: ""
       # team_reviewers: ""

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  libssl-dev \
  python3-dev \
  gcc \
- make
+ make \
+ git
 
 
 RUN pip install --upgrade pip setuptools


### PR DESCRIPTION
- Added a PR template for future pull requests
- Python requirements upgrade should target `main`, not `master`, as there is no `master` branch for this repository
- Docker publish action is failing right now because git is not installed. I looked at the edx-enterprise repository to mirror what's being done there to install requirements from github.