### PR TITLE
fix: update dictionary settings list

### DIFF
--- a/edx_exams/settings/production.py
+++ b/edx_exams/settings/production.py
@@ -14,7 +14,7 @@ LOGGING = get_logger_config()
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('JWT_AUTH',)
+DICT_UPDATE_KEYS = ('JWT_AUTH', 'EDX_DRF_EXTENSIONS',)
 
 # This may be overridden by the YAML in edx_exams_CFG,
 # but it should be here as a default.


### PR DESCRIPTION
**Description:** The sandbox config was overriding `EDX_DRF_EXTENSIONS`, which prevents user attributes from being correctly mapped from the JWT token. There is already a constant in the production settings file used to keep track of dictionary settings (so that only keys within the dictionary are updated, not the entire dictionary), so `EDX_DRF_EXTENSIONS` should be added to that constant.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
