### PR TITLE
feat: get endpoint for exam config

### DIFF
--- a/edx_exams/apps/api/permissions.py
+++ b/edx_exams/apps/api/permissions.py
@@ -7,3 +7,15 @@ class StaffUserPermissions(BasePermission):
 
     def has_permission(self, request, view):
         return request.user.is_staff
+
+
+class StaffUserOrReadOnlyPermissions(BasePermission):
+    """
+    Permission class granting write access to staff users and
+    read-only access to authenticated users
+    """
+    def has_permission(self, request, view):
+        return request.user.is_staff or (
+            request.user.is_authenticated and
+            request.method == 'GET'
+        )

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -12,7 +12,7 @@ from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from edx_exams.apps.api.permissions import StaffUserPermissions, StaffUserOrReadOnlyPermissions
+from edx_exams.apps.api.permissions import StaffUserOrReadOnlyPermissions, StaffUserPermissions
 from edx_exams.apps.api.serializers import ExamSerializer, ProctoringProviderSerializer
 from edx_exams.apps.core.exam_types import get_exam_type
 from edx_exams.apps.core.models import CourseExamConfiguration, Exam, ProctoringProvider

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -190,6 +190,13 @@ class CourseExamConfigurationsView(APIView):
     Given a course id and a proctoring provider name, this view will either create a new course exam configuration
     (if one doesn't exist), or modify the proctoring provider on an existing course exam config.
 
+    HTTP GET
+    Gets CourseExamConfiguration.
+    **Returns**
+    {
+        'provider': 'test_provider',
+    }
+
     HTTP PATCH
     Creates or updates a CourseExamConfiguration.
     Expected PATCH data: {
@@ -218,6 +225,9 @@ class CourseExamConfigurationsView(APIView):
     def get(self, request, course_id):
         """
         Get exam configuration for a course
+
+        TODO: This view should use a serializer to ensure the read/write bodies are the same
+        once more fields are added.
         """
         try:
             provider = CourseExamConfiguration.objects.get(course_id=course_id).provider


### PR DESCRIPTION
**JIRA:** [MST-1527](https://2u-internal.atlassian.net/browse/MST-1527)

**Description:** GET course exam config. This is needed to fetch the currently selected provider in course-authoring.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
