### PR TITLE
feat: undo migration 'fork'

### DIFF
--- a/edx_exams/apps/lti/signals/handlers.py
+++ b/edx_exams/apps/lti/signals/handlers.py
@@ -2,10 +2,10 @@
 edX Exams Signal Handlers
 """
 from django.dispatch import receiver
-from lti_consumer.signals.signals import LTI_1P3_PROCTORING_ASSESSMENT_STARTED
+# from lti_consumer.signals.signals import LTI_1P3_PROCTORING_ASSESSMENT_STARTED
 
 
-@receiver(LTI_1P3_PROCTORING_ASSESSMENT_STARTED)
+# @receiver(LTI_1P3_PROCTORING_ASSESSMENT_STARTED)
 def assessment_started(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Signal handler for the lti_consumer LTI_1P3_PROCTORING_ASSESSMENT_STARTED signal.

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -8,8 +8,8 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods
-from lti_consumer.api import get_end_assessment_return, get_lti_1p3_launch_start_url
-from lti_consumer.data import Lti1p3LaunchData, Lti1p3ProctoringLaunchData
+# from lti_consumer.api import get_end_assessment_return, get_lti_1p3_launch_start_url
+# from lti_consumer.data import Lti1p3LaunchData, Lti1p3ProctoringLaunchData
 from lti_consumer.models import LtiConfiguration
 
 from edx_exams.apps.core.models import ExamAttempt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -17,3 +17,6 @@ edx-rest-api-client
 lti-consumer-xblock===6.3.0
 mysqlclient
 pytz
+
+# Libraries to install from GitHub
+git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1#egg=lti-consumer-xblock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,8 +8,6 @@ appdirs==1.4.4
     # via fs
 asgiref==3.5.2
     # via django
-attrs==22.1.0
-    # via lti-consumer-xblock
 bleach==5.0.1
     # via lti-consumer-xblock
 certifi==2022.9.24
@@ -31,7 +29,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   pyjwt
     #   social-auth-core
@@ -70,7 +68,7 @@ django-extensions==3.2.1
     # via -r requirements/base.in
 django-filter==22.1
     # via lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/base.in
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
@@ -128,13 +126,13 @@ jsonfield==3.1.0
     # via lti-consumer-xblock
 lazy==1.5
     # via lti-consumer-xblock
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/base.in
 lxml==4.9.1
     # via
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   lti-consumer-xblock
     #   xblock-utils
@@ -164,7 +162,7 @@ psutil==5.9.4
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   lti-consumer-xblock
     #   pyjwkest
@@ -219,7 +217,7 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   django-rest-swagger
     #   xblock-utils
@@ -250,7 +248,7 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
 web-fragments==2.0.0
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ idna==3.4
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via tox
@@ -36,9 +36,9 @@ six==1.16.0
     # via tox
 tomli==2.0.1
     # via tox
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/ci.in
-urllib3==1.26.12
+urllib3==1.26.13
     # via requests
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/validation.txt
     #   django
-astroid==2.12.12
+astroid==2.12.13
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -20,7 +20,6 @@ astroid==2.12.12
 attrs==22.1.0
     # via
     #   -r requirements/validation.txt
-    #   lti-consumer-xblock
     #   pytest
 bleach==5.0.1
     # via
@@ -82,10 +81,11 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/validation.txt
     #   pyjwt
+    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/validation.txt
@@ -94,7 +94,7 @@ defusedxml==0.7.1
     #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==7.0.1
+diff-cover==7.1.1
     # via -r requirements/dev.in
 dill==0.3.6
     # via
@@ -146,7 +146,7 @@ django-filter==22.1
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/validation.txt
 django-rest-swagger==2.2.0
     # via -r requirements/validation.txt
@@ -201,13 +201,13 @@ edx-opaque-keys==2.3.0
     #   lti-consumer-xblock
 edx-rest-api-client==5.5.0
     # via -r requirements/validation.txt
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via
     #   -r requirements/validation.txt
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/validation.txt
-faker==15.3.1
+faker==15.3.3
     # via
     #   -r requirements/validation.txt
     #   factory-boy
@@ -228,7 +228,7 @@ idna==3.4
     # via
     #   -r requirements/validation.txt
     #   requests
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   -r requirements/validation.txt
     #   keyring
@@ -253,6 +253,11 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/validation.txt
     #   keyring
+jeepney==0.8.0
+    # via
+    #   -r requirements/validation.txt
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/validation.txt
@@ -275,14 +280,14 @@ lazy-object-proxy==1.8.0
     # via
     #   -r requirements/validation.txt
     #   astroid
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/validation.txt
 lxml==4.9.1
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
@@ -341,13 +346,13 @@ pep517==0.13.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/pip-tools.txt
 pkginfo==1.8.3
     # via
     #   -r requirements/validation.txt
     #   twine
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via
     #   -r requirements/validation.txt
     #   pylint
@@ -368,13 +373,13 @@ py==1.11.0
     # via
     #   -r requirements/validation.txt
     #   tox
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via -r requirements/validation.txt
 pycparser==2.21
     # via
     #   -r requirements/validation.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
@@ -400,7 +405,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.5
+pylint==2.15.7
     # via
     #   -r requirements/validation.txt
     #   edx-lint
@@ -448,7 +453,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   xblock
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via
     #   -r requirements/validation.txt
     #   code-annotations
@@ -513,11 +518,15 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/validation.txt
     #   ruamel-yaml
+secretstorage==3.3.3
+    # via
+    #   -r requirements/validation.txt
+    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/validation.txt
     #   django-rest-swagger
@@ -585,11 +594,11 @@ tomlkit==0.11.6
     # via
     #   -r requirements/validation.txt
     #   pylint
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/validation.txt
 twine==4.0.1
     # via -r requirements/validation.txt
-types-toml==0.10.8
+types-toml==0.10.8.1
     # via
     #   -r requirements/validation.txt
     #   responses
@@ -604,13 +613,13 @@ uritemplate==4.1.1
     #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/validation.txt
     #   requests
     #   responses
     #   twine
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via
     #   -r requirements/validation.txt
     #   tox
@@ -644,7 +653,7 @@ xblock-utils==3.0.0
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
-zipp==3.10.0
+zipp==3.11.0
     # via
     #   -r requirements/validation.txt
     #   importlib-metadata

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,7 +14,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.12.12
+astroid==2.12.13
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -22,7 +22,6 @@ astroid==2.12.12
 attrs==22.1.0
     # via
     #   -r requirements/test.txt
-    #   lti-consumer-xblock
     #   pytest
 babel==2.11.0
     # via sphinx
@@ -78,10 +77,11 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
+    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -137,7 +137,7 @@ django-filter==22.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/test.txt
 django-rest-swagger==2.2.0
     # via -r requirements/test.txt
@@ -196,13 +196,13 @@ edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
 edx-sphinx-theme==3.0.0
     # via -r requirements/doc.in
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==15.3.1
+faker==15.3.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -225,7 +225,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   keyring
     #   sphinx
@@ -248,6 +248,10 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.2.3
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -268,14 +272,14 @@ lazy-object-proxy==1.8.0
     # via
     #   -r requirements/test.txt
     #   astroid
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/test.txt
 lxml==4.9.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
@@ -330,7 +334,7 @@ pep517==0.13.0
     # via build
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -352,7 +356,7 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
@@ -376,7 +380,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.5
+pylint==2.15.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -423,7 +427,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   xblock
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -483,11 +487,13 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
+secretstorage==3.3.3
+    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -570,11 +576,11 @@ tomlkit==0.11.6
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/test.txt
 twine==4.0.1
     # via -r requirements/doc.in
-types-toml==0.10.8
+types-toml==0.10.8.1
     # via
     #   -r requirements/test.txt
     #   responses
@@ -589,13 +595,13 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -625,7 +631,7 @@ xblock-utils==3.0.0
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -12,7 +12,7 @@ packaging==21.3
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.9.0
+pip-tools==6.10.0
     # via -r requirements/pip-tools.in
 pyparsing==3.0.9
     # via packaging

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.38.4
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1
     # via -r requirements/pip.in
-setuptools==65.5.1
+setuptools==65.6.3
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -12,10 +12,6 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-attrs==22.1.0
-    # via
-    #   -r requirements/base.txt
-    #   lti-consumer-xblock
 bleach==5.0.1
     # via
     #   -r requirements/base.txt
@@ -48,7 +44,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -94,7 +90,7 @@ django-filter==22.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
@@ -179,14 +175,14 @@ lazy==1.5
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/base.txt
 lxml==4.9.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
@@ -235,7 +231,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
@@ -315,7 +311,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -358,7 +354,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/base.txt
     #   requests
@@ -386,7 +382,7 @@ xblock-utils==3.0.0
     #   lti-consumer-xblock
 zope-event==4.5.0
     # via gevent
-zope-interface==5.5.1
+zope-interface==5.5.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ asgiref==3.5.2
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.12.12
+astroid==2.12.13
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -20,7 +20,6 @@ astroid==2.12.12
 attrs==22.1.0
     # via
     #   -r requirements/test.txt
-    #   lti-consumer-xblock
     #   pytest
 bleach==5.0.1
     # via
@@ -72,10 +71,11 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/test.txt
     #   pyjwt
+    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via -r requirements/test.txt
@@ -131,7 +131,7 @@ django-filter==22.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/test.txt
 django-rest-swagger==2.2.0
     # via -r requirements/test.txt
@@ -184,13 +184,13 @@ edx-opaque-keys==2.3.0
     #   lti-consumer-xblock
 edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==15.3.1
+faker==15.3.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -211,7 +211,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   keyring
     #   twine
@@ -234,6 +234,10 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.2.3
     # via keyring
+jeepney==0.8.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -253,14 +257,14 @@ lazy-object-proxy==1.8.0
     # via
     #   -r requirements/test.txt
     #   astroid
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/test.txt
 lxml==4.9.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
@@ -311,7 +315,7 @@ pbr==5.11.0
     #   stevedore
 pkginfo==1.8.3
     # via twine
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -329,13 +333,13 @@ py==1.11.0
     # via
     #   -r requirements/test.txt
     #   tox
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via -r requirements/quality.in
 pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
@@ -359,7 +363,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.5
+pylint==2.15.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -406,7 +410,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   xblock
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -462,11 +466,13 @@ ruamel-yaml-clib==0.2.7
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
+secretstorage==3.3.3
+    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -528,11 +534,11 @@ tomlkit==0.11.6
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/test.txt
 twine==4.0.1
     # via -r requirements/quality.in
-types-toml==0.10.8
+types-toml==0.10.8.1
     # via
     #   -r requirements/test.txt
     #   responses
@@ -547,13 +553,13 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -583,7 +589,7 @@ xblock-utils==3.0.0
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-zipp==3.10.0
+zipp==3.11.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,15 +12,12 @@ asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.12.12
+astroid==2.12.13
     # via
     #   pylint
     #   pylint-celery
 attrs==22.1.0
-    # via
-    #   -r requirements/base.txt
-    #   lti-consumer-xblock
-    #   pytest
+    # via pytest
 bleach==5.0.1
     # via
     #   -r requirements/base.txt
@@ -66,7 +63,7 @@ coverage[toml]==6.5.0
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -119,7 +116,7 @@ django-filter==22.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
@@ -168,11 +165,11 @@ edx-opaque-keys==2.3.0
     #   lti-consumer-xblock
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==15.3.1
+faker==15.3.3
     # via factory-boy
 filelock==3.8.0
     # via
@@ -217,14 +214,14 @@ lazy==1.5
     #   lti-consumer-xblock
 lazy-object-proxy==1.8.0
     # via astroid
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via -r requirements/base.txt
 lxml==4.9.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
@@ -269,7 +266,7 @@ pbr==5.11.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via
     #   pylint
     #   virtualenv
@@ -287,7 +284,7 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
@@ -305,7 +302,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.5
+pylint==2.15.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -345,7 +342,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   xblock
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via code-annotations
 python3-openid==3.2.0
     # via
@@ -393,7 +390,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -446,9 +443,9 @@ tomli==2.0.1
     #   tox
 tomlkit==0.11.6
     # via pylint
-tox==3.27.0
+tox==3.27.1
     # via -r requirements/test.in
-types-toml==0.10.8
+types-toml==0.10.8.1
     # via responses
 typing-extensions==4.4.0
     # via
@@ -459,12 +456,12 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/base.txt
     #   requests
     #   responses
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via tox
 web-fragments==2.0.0
     # via

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -14,7 +14,7 @@ asgiref==3.5.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   django
-astroid==2.12.12
+astroid==2.12.13
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -24,7 +24,6 @@ attrs==22.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-    #   lti-consumer-xblock
     #   pytest
 bleach==5.0.1
     # via
@@ -88,11 +87,12 @@ coverage[toml]==6.5.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.3
+cryptography==38.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
+    #   secretstorage
     #   social-auth-core
 ddt==1.6.0
     # via
@@ -162,7 +162,7 @@ django-filter==22.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-django-model-utils==4.2.0
+django-model-utils==4.3.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -237,7 +237,7 @@ edx-rest-api-client==5.5.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-exceptiongroup==1.0.1
+exceptiongroup==1.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -246,7 +246,7 @@ factory-boy==3.2.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-faker==15.3.1
+faker==15.3.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -272,7 +272,7 @@ idna==3.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==5.0.0
+importlib-metadata==5.1.0
     # via
     #   -r requirements/quality.txt
     #   keyring
@@ -301,6 +301,11 @@ jaraco-classes==3.2.3
     # via
     #   -r requirements/quality.txt
     #   keyring
+jeepney==0.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
+    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
@@ -326,7 +331,7 @@ lazy-object-proxy==1.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   astroid
-lti-consumer-xblock===6.3.0
+lti-consumer-xblock @ git+https://github.com/openedx/xblock-lti-consumer.git@c32e713935daae87d14da52996cbc4fb1932b0d1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -336,7 +341,7 @@ lxml==4.9.1
     #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
-mako==1.2.3
+mako==1.2.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -404,7 +409,7 @@ pkginfo==1.8.3
     # via
     #   -r requirements/quality.txt
     #   twine
-platformdirs==2.5.3
+platformdirs==2.5.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -426,14 +431,14 @@ py==1.11.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   tox
-pycodestyle==2.9.1
+pycodestyle==2.10.0
     # via -r requirements/quality.txt
 pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.15.0
+pycryptodomex==3.16.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -461,7 +466,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.15.5
+pylint==2.15.7
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -521,7 +526,7 @@ python-dateutil==2.8.2
     #   edx-drf-extensions
     #   faker
     #   xblock
-python-slugify==6.1.2
+python-slugify==7.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -595,12 +600,16 @@ ruamel-yaml-clib==0.2.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   ruamel-yaml
+secretstorage==3.3.3
+    # via
+    #   -r requirements/quality.txt
+    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.17.6
+simplejson==3.18.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -675,13 +684,13 @@ tomlkit==0.11.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
-tox==3.27.0
+tox==3.27.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
 twine==4.0.1
     # via -r requirements/quality.txt
-types-toml==0.10.8
+types-toml==0.10.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -699,14 +708,14 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.12
+urllib3==1.26.13
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine
-virtualenv==20.16.6
+virtualenv==20.17.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -743,7 +752,7 @@ xblock-utils==3.0.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-zipp==3.10.0
+zipp==3.11.0
     # via
     #   -r requirements/quality.txt
     #   importlib-metadata


### PR DESCRIPTION
**JIRA:** https://2u-internal.atlassian.net/browse/MST-1719

**Description:** This pulls in the old POC code with an additional commit to undo the migration applied by that branch that does not exist in master. Note this will temporarily break the LTI launch at runtime but the app otherwise still works as I had to comment out some imports that don't exist.

The problematic migration is here: [0015_add_remaining_fields_to_lti_config.py](https://github.com/openedx/xblock-lti-consumer/blob/zhancock/unmigrate/lti_consumer/migrations/0015_add_remaining_fields_to_lti_config.py)

The commit we're installing has a new migration to undo those DB changes: [0016_remove_lti_fields.py](https://github.com/openedx/xblock-lti-consumer/blob/zhancock/unmigrate/lti_consumer/migrations/0016_remove_lti_fields.py)

The plan:

1. Merge this which will run migration [0016_remove_lti_fields.py](https://github.com/openedx/xblock-lti-consumer/blob/zhancock/unmigrate/lti_consumer/migrations/0016_remove_lti_fields.py). This puts us back in a clean state.
2. Make another PR and point xblock-lti-consumer back at the latest release. The remaining migrations in that app should run as if nothing bad ever happened. These two ghost migrations go away forever.
