### PR TITLE
feat: authenticate LTI exams launch

### DIFF
--- a/edx_exams/apps/lti/utils.py
+++ b/edx_exams/apps/lti/utils.py
@@ -5,7 +5,4 @@ from django.conf import settings
 
 
 def get_lti_root():
-    if hasattr(settings, 'LTI_ROOT_URL_OVERRIDE'):
-        return settings.LTI_ROOT_URL_OVERRIDE
-    else:
-        return settings.ROOT_URL
+    return settings.ROOT_URL

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -10,16 +10,17 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from rest_framework.decorators import authentication_classes, permission_classes
-from rest_framework.permissions import IsAuthenticated
 from lti_consumer.api import get_end_assessment_return, get_lti_1p3_launch_start_url
 from lti_consumer.data import Lti1p3LaunchData, Lti1p3ProctoringLaunchData
 from lti_consumer.models import LtiConfiguration
+from rest_framework.decorators import authentication_classes, permission_classes
+from rest_framework.permissions import IsAuthenticated
 
 from edx_exams.apps.core.models import ExamAttempt
 from edx_exams.apps.lti.utils import get_lti_root
 
 EDX_OAUTH_BACKEND = 'auth_backends.backends.EdXOAuth2'
+
 
 @require_http_methods(['GET'])
 @authentication_classes((JwtAuthentication,))
@@ -31,7 +32,7 @@ def start_proctoring(request, attempt_id):
     # TODO: Here we'd do all the start of proctoring things.
 
     # user is authenticated via JWT so use that to create a
-    # session with this service's authentication backend 
+    # session with this service's authentication backend
     request.user.backend = EDX_OAUTH_BACKEND
     login(request, request.user)
 

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -93,6 +93,10 @@ ENABLE_AUTO_AUTH = True
 
 LOGGING = get_logger_config(debug=DEBUG)
 
+SESSION_COOKIE_SAMESITE = None
+SESSION_COOKIE_SECURE = None
+SESSION_COOKIE_DOMAIN = 'localhost'
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -97,6 +97,9 @@ SESSION_COOKIE_SAMESITE = None
 SESSION_COOKIE_SECURE = None
 SESSION_COOKIE_DOMAIN = 'localhost'
 
+ROOT_URL = 'http://localhost:8740'
+LMS_ROOT_URL = 'http://localhost:18000'
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
**JIRA:** [MST-1724](https://2u-internal.atlassian.net/browse/MST-1724?atlOrigin=eyJpIjoiNzliZTFjYjA1YzI1NGRlMTlhYThkODU2ZWI5YmY2NDgiLCJwIjoiaiJ9)

**Description:** 
In order to make use of the edx browser JWT the client needs to explicitly request its use with a custom header. As a result, any redirect that occurs as part of the LTI launch flow cannot be authenticated using this JWT. This PR will create an explicit django session with the exam service when `/start_proctoring/` is called so those LTI callbacks will authenticate using the django session cookie. This is the one endpoint that can make use of the JWT since we expect this request to come from the learning MFE.

The downside for now is the initial request must come from the MFE and simply doing a GET request to /start_proctoring/<id> will no longer work. If you want to do a launch you'll need to set the use-jwt header using a browser tool. Here's how I'm doing that with requestly https://app.requestly.io/rules/#sharedList/1671117948648-apply-edx-exams-jwt
