### PR TITLE
fix: allow cross-site session cookie for LTI launch

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -181,6 +181,8 @@ TEMPLATES = [
 # multiple Django services are running behind the same hostname.
 # Detailed information at: https://docs.djangoproject.com/en/dev/ref/settings/
 SESSION_COOKIE_NAME = 'edx_exams_sessionid'
+SESSION_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_NAME = 'edx_exams_csrftoken'
 LANGUAGE_COOKIE_NAME = 'edx_exams_language'
 # END COOKIE CONFIGURATION


### PR DESCRIPTION
Testing #59 in stage and found we lose the session in the final request of the flow. We need to accept the session cookie when the 'start assessment' button is hit inside the proctoring tool which is cross-site.