### PR TITLE
feat: add proctoring tool launch button

### DIFF
--- a/edx_exams/templates/admin/core/examattempt/change_form.html
+++ b/edx_exams/templates/admin/core/examattempt/change_form.html
@@ -1,0 +1,16 @@
+{% extends 'admin/change_form.html' %}
+
+{% block content %}
+    {{ block.super }}
+    {% if adminform.form.instance.exam.provider %}
+        <div class="launch-row">
+            <a
+                target="_blank"
+                href="/lti/start_proctoring/{{adminform.form.instance.id}}"
+                style="color:white;background-color:blue;padding:10px 15px;"
+            >
+                Launch {{ adminform.form.instance.exam.provider.verbose_name }}
+            </a>
+        </div>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
**JIRA:** [MST-1735](https://2u-internal.atlassian.net/browse/MST-1735)

**Description:** Adds a button to launch the proctoring tool for an exam attempt in Django admin. This is a temporary measure to perform an LTI launch without the courseware frontend.

![Screen Shot 2023-01-05 at 10 51 49 AM](https://user-images.githubusercontent.com/5661461/210823269-d485b544-c961-4ed5-bd84-1d7dce2750f0.png)


