### PR TITLE
fix: LTI link url should not be 'internal'

### DIFF
--- a/edx_exams/apps/core/admin.py
+++ b/edx_exams/apps/core/admin.py
@@ -4,6 +4,8 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
 
+from edx_exams.apps.lti.utils import get_lti_root
+
 from .models import CourseExamConfiguration, Exam, ExamAttempt, ProctoringProvider, User
 
 
@@ -41,6 +43,13 @@ class ExamAttemptAdmin(admin.ModelAdmin):
                     'allowed_time_limit_mins')
     search_fields = ('user__username', 'attempt_number')
     ordering = ('-modified',)
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['LTI_ROOT'] = get_lti_root()
+        return super().change_view(
+            request, object_id, form_url, extra_context=extra_context,
+        )
 
 
 class CourseExamConfigurationAdmin(admin.ModelAdmin):

--- a/edx_exams/templates/admin/core/examattempt/change_form.html
+++ b/edx_exams/templates/admin/core/examattempt/change_form.html
@@ -6,7 +6,7 @@
         <div class="launch-row">
             <a
                 target="_blank"
-                href="/lti/start_proctoring/{{adminform.form.instance.id}}"
+                href="{{LTI_ROOT}}/lti/start_proctoring/{{adminform.form.instance.id}}"
                 style="color:white;background-color:blue;padding:10px 15px;"
             >
                 Launch {{ adminform.form.instance.exam.provider.verbose_name }}


### PR DESCRIPTION
Bug found while testing LTI launch on stage. The host url for this launch would end up being edx-exams-internal.edx.org which would cause the session cookie to get set on the internal domain. We want to launch to edx-exams.edx.org so any redirect from the tool (which would use edx-exams.edx.org) includes the session cookie.