### PR TITLE
feat: automatically use jwt auth

### DIFF
--- a/edx_exams/apps/core/middleware.py
+++ b/edx_exams/apps/core/middleware.py
@@ -1,0 +1,23 @@
+"""
+Middleware that checks if in incoming request has a browser jwt cookie
+and enables JWT auth for that request.
+
+This is a temporary workaround that allows easier testing of browser endpoints in
+absence of a frontend UI. Normally a frontend application must explicity request
+the JWT token to be used for auth by setting USE_JWT_COOKIE_HEADER.
+"""
+from django.utils.deprecation import MiddlewareMixin
+from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
+from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_header_payload_name
+
+
+class ForceJWTAuthMiddleware(MiddlewareMixin):  # pragma: no cover
+    """ Middleware to automically enable JWT auth for browser requests """
+    def process_request(self, request):  # pylint: disable=missing-function-docstring
+        # prevent lti callback endpoints from reading jwt, we want to ensure
+        # the session token generated for these is used instead
+        if request.path.startswith('/lti/lti_consumer'):
+            return
+
+        if request.COOKIES.get(jwt_cookie_header_payload_name(), None):
+            request.META[USE_JWT_COOKIE_HEADER] = "true"

--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -61,6 +61,8 @@ MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
+    # Forces JWT auth if edx JWT cookie exists
+    'edx_exams.apps.core.middleware.ForceJWTAuthMiddleware',
     'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
This may be a helpful fix as we build out browser endpoints in M3. Right now in order to test our JWT endpoints without a frontend it requires a browser extension like requestly to apply the USE_JWT_COOKIE_HEADER (example - https://app.requestly.io/rules/#sharedList/1671117948648-apply-edx-exams-jwt). This would make it so that header is implied if a JWT cookie is sent by the browser.

This is a bit jankey... but may be removed once we've completed the UI work.