### PR TITLE
feat: add endpoint to create exam attempt

### DIFF
--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -29,4 +29,7 @@ urlpatterns = [
     path('exams/attempt/<int:attempt_id>',
          ExamAttemptView.as_view(),
          name='exams-attempt',),
+    path('exams/attempt',
+         ExamAttemptView.as_view(),
+         name='exams-attempt',),
 ]

--- a/edx_exams/apps/core/exceptions.py
+++ b/edx_exams/apps/core/exceptions.py
@@ -16,3 +16,22 @@ class ExamIllegalStatusTransition(ExamBaseException):
     Raised if a state transition is not allowed, e.g. going from submitted to started or trying
     to start an already started exam
     """
+
+
+class ExamAttemptOnPastDueExam(ExamBaseException):
+    """
+    Raised if a student tries to create an exam attempt for a non-practice exam whose
+    due date has already passed
+    """
+
+
+class ExamDoesNotExist(ExamBaseException):
+    """
+    Raised if trying to access an exam that does not exist
+    """
+
+
+class ExamAttemptAlreadyExists(ExamBaseException):
+    """
+    Raised when trying to start an exam when an Exam Attempt already exists.
+    """

--- a/edx_exams/apps/core/models.py
+++ b/edx_exams/apps/core/models.py
@@ -116,6 +116,17 @@ class Exam(TimeStampedModel):
     def __str__(self):      # pragma: no cover
         return self.exam_name
 
+    @classmethod
+    def get_exam_by_id(cls, exam_id):
+        """
+        Return Exam for a given id
+        """
+        try:
+            exam = cls.objects.get(id=exam_id)
+        except cls.DoesNotExist:
+            exam = None
+        return exam
+
 
 class ExamAttempt(TimeStampedModel):
     """
@@ -157,12 +168,12 @@ class ExamAttempt(TimeStampedModel):
         verbose_name = 'exam attempt'
 
     @classmethod
-    def get_current_exam_attempt(cls, user, exam):
+    def get_current_exam_attempt(cls, user_id, exam_id):
         """
         Given a user and exam, get the user's latest exam attempt, if exists.
         """
         try:
-            exam_attempt = cls.objects.filter(user=user, exam=exam).latest('created')
+            exam_attempt = cls.objects.filter(user_id=user_id, exam=exam_id).latest('created')
         except ObjectDoesNotExist:
             exam_attempt = None
         return exam_attempt


### PR DESCRIPTION
**JIRA:** [MST-1640](https://2u-internal.atlassian.net/browse/MST-1640)

**Description:** This PR adds support for an endpoint that allows exam attempt creation. The endpoint expects the following data 
`{ 
  exam_id: <id>, 
  start_clock: <Boolean>, 
}`

If the endpoint is called for a non-practice exam whose due date has passed, an exception is thrown. To mimic edx-proctoring behavior, attempts can be created for practice exams whose due date has passed.

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
