### PR TITLE
feat: move exam access token to response body

### DIFF
--- a/edx_exams/apps/core/constants.py
+++ b/edx_exams/apps/core/constants.py
@@ -17,5 +17,4 @@ COURSE_ID_PATTERN = rf'(?P<course_id>({INTERNAL_COURSE_KEY_PATTERN}|{EXTERNAL_CO
 
 CONTENT_ID_PATTERN = r'(?P<content_id>([A-Za-z0-9-_:@\+]+))'
 
-# EXAM_ID_PATTERN = r'(/\d+/)'
 EXAM_ID_PATTERN = r'(?P<exam_id>\d+)'

--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -268,8 +268,4 @@ PLATFORM_NAME = 'Your Platform Name Here'
 # Set up logging for development use (logging to stdout)
 LOGGING = get_logger_config(debug=DEBUG)
 
-# Exam access token cookie config
-ACCESS_TOKEN_COOKIE_NAME = 'exam_access_token'
-ACCESS_TOKEN_COOKIE_DOMAIN = None
-
 LEARNING_MICROFRONTEND_URL = None

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -121,8 +121,6 @@ ROOT_URL = 'http://localhost:8740'
 LMS_ROOT_URL = 'http://localhost:18000'
 LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
 
-ACCESS_TOKEN_COOKIE_DOMAIN = 'localhost'
-
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:2001',
     LEARNING_MICROFRONTEND_URL,


### PR DESCRIPTION
**JIRA:** [MST-1781](https://2u-internal.atlassian.net/browse/MST-1781)

**Description:** This PR moves the exam access token from a cookie to the response body. 
This PR addresses only the first criteria: 
Have the exam service return the token in the request body instead of a cookie.
- Include the expiration as an additional field. This can be used for UI performance improvements if needed later down the line.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
