### PR TITLE
feat: add learning mfe url to cors whitelist

### DIFF
--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -125,6 +125,7 @@ ACCESS_TOKEN_COOKIE_DOMAIN = 'localhost'
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:2001',
+    LEARNING_MICROFRONTEND_URL,
 )
 
 #####################################################################


### PR DESCRIPTION
**JIRA:** n/a

**Description:** In order to be able to make calls to edx-exams in the frontend MFE locally, the url needs to be added to the cors whitelist in local.py.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
