### PR TITLE
feat: only one active attempt per user at a time

### DIFF
--- a/edx_exams/apps/core/models.py
+++ b/edx_exams/apps/core/models.py
@@ -218,6 +218,18 @@ class ExamAttempt(TimeStampedModel):
             attempt = None
         return attempt
 
+    @classmethod
+    def check_no_other_active_attempts_for_user(cls, user_id, attempt_id):
+        """
+        Return true if no active exam attempts exist for the user
+        Return false otherwise
+        """
+        try:
+            cls.objects.exclude(id=attempt_id).get(user_id=user_id, status__in=ExamAttemptStatus.in_progress_statuses)
+            return False
+        except cls.DoesNotExist:
+            return True
+
 
 class CourseExamConfiguration(TimeStampedModel):
     """

--- a/edx_exams/apps/core/statuses.py
+++ b/edx_exams/apps/core/statuses.py
@@ -44,6 +44,9 @@ class ExamAttemptStatus:
     # the exam has errored
     error = 'error'
 
+    # list of all statuses for active/in-progress exam attempts
+    in_progress_statuses = [started, ready_to_submit]
+
     # list of all statuses considered completed
     completed_statuses = [timed_out, submitted, verified, rejected, error,]
 

--- a/edx_exams/apps/core/tests/test_api.py
+++ b/edx_exams/apps/core/tests/test_api.py
@@ -324,6 +324,21 @@ class TestUpdateAttemptStatus(ExamsAPITestCase):
             update_attempt_status(attempt.id, to_status)
         self.assertIn('A status transition from', str(exc.exception))
 
+    def test_cannot_start_if_other_attempts_active(self):
+        """
+        Test that you cannot start another exam attempt if one is already active
+        """
+        # Already active exam attempt
+        ExamAttempt.objects.create(
+            user=self.user,
+            exam=self.exam,
+            attempt_number=1,
+            status=ExamAttemptStatus.started,
+        )
+        with self.assertRaises(ExamIllegalStatusTransition) as exc:
+            update_attempt_status(self.exam_attempt.id, ExamAttemptStatus.started)
+        self.assertIn('another exam attempt is currently active!', str(exc.exception))
+
 
 class TestGetAttemptById(ExamsAPITestCase):
     """


### PR DESCRIPTION
- Added functionality to models.py api.py to check that a user has no other active attempts when trying to start and exam attempt
- Refactored api.py code to compartmentalize the various if/else statements and such

**JIRA:** [Link to JIRA ticket](https://2u-internal.atlassian.net/browse/MST-1798)

**Description:** Only allow a user to start an exam if no other exam attempts are active.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
