### PR TITLE
fix: bugs found for timed exams

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1278,3 +1278,27 @@ class CourseExamAttemptViewTest(ExamsAPITestCase):
 
         self.assertEqual(response_exam['attempt'], StudentAttemptSerializer(current_attempt).data)
         mock_check_if_exam_timed_out.assert_called_once_with(current_attempt)
+
+    def test_timed_exam(self):
+        """
+        Test that None is returned as the backend for a timed attempt
+        """
+        timed_content_id = 'block-v1:edX+test+2023+type@sequential+block@22222222'
+
+        Exam.objects.create(
+            resource_id=str(uuid.uuid4()),
+            course_id=self.course_id,
+            content_id=timed_content_id,
+            exam_name='test_exam',
+            exam_type='timed',
+            time_limit_mins=30,
+            due_date='2040-07-01T00:00:00Z',
+            hide_after_due=False,
+            is_active=True
+        )
+
+        response = self.get_api(self.user, self.course_id, timed_content_id)
+        response_exam = response.data['exam']
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response_exam['backend'])

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -549,7 +549,7 @@ class ExamAttemptView(ExamsAPIView):
 class CourseExamAttemptView(ExamsAPIView):
     """
     Endpoint for getting timed or proctored exam and its attempt data given the request user.
-    /exam/attempt/course_id/{course_id}/content_id/{content_id}
+    /student/exam/attempt/course_id/{course_id}/content_id/{content_id}
     Supports:
         HTTP GET:
 
@@ -564,6 +564,8 @@ class CourseExamAttemptView(ExamsAPIView):
                 },
             }
     """
+
+    authentication_classes = (JwtAuthentication,)
 
     def get(self, request, course_id, content_id):
         """
@@ -583,7 +585,8 @@ class CourseExamAttemptView(ExamsAPIView):
         serialized_exam['type'] = exam.exam_type
         serialized_exam['is_proctored'] = exam_type_class.is_proctored
         serialized_exam['is_practice_exam'] = exam_type_class.is_practice
-        serialized_exam['backend'] = exam.provider.verbose_name
+        # timed exams will have None as a backend
+        serialized_exam['backend'] = exam.provider.verbose_name if exam.provider is not None else None
         exam_attempt = get_current_exam_attempt(request.user.id, exam.id)
         if exam_attempt is not None:
             exam_attempt = check_if_exam_timed_out(exam_attempt)

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -10,6 +10,7 @@ from edx_api_doc_tools import path_parameter, schema
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework.generics import ListAPIView
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from token_utils.api import sign_token_for
 
@@ -417,6 +418,7 @@ class LatestExamAttemptView(ExamsAPIView):
     """
 
     authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
 
     def get(self, request):
         """
@@ -477,6 +479,7 @@ class ExamAttemptView(ExamsAPIView):
     """
 
     authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
 
     def put(self, request, attempt_id):
         """
@@ -566,6 +569,7 @@ class CourseExamAttemptView(ExamsAPIView):
     """
 
     authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
 
     def get(self, request, course_id, content_id):
         """

--- a/edx_exams/apps/core/api.py
+++ b/edx_exams/apps/core/api.py
@@ -233,7 +233,11 @@ def create_exam_attempt(exam_id, user_id):
     practice_exam_types = [PracticeExamType, OnboardingExamType]
 
     # if exam is past the due date, and it is a non-practice exam, raise error
-    if get_exam_type(exam_obj.exam_type) not in practice_exam_types and timezone.now() > exam_obj.due_date:
+    if (
+        get_exam_type(exam_obj.exam_type) not in practice_exam_types
+        and exam_obj.due_date
+        and timezone.now() > exam_obj.due_date
+    ):
         err_msg = (
             f'user_id={user_id} trying to create exam attempt for past due non-practice exam '
             f'exam_id={exam_id} in course_id={exam_obj.course_id}. Do not register an exam attempt!'

--- a/edx_exams/apps/core/tests/test_api.py
+++ b/edx_exams/apps/core/tests/test_api.py
@@ -529,7 +529,7 @@ class TestCreateExamAttempt(ExamsAPITestCase):
 
     def test_bad_exam_id(self):
         """
-        Test that a non existant exam raises an error
+        Test that a non existent exam raises an error
         """
         fake_exam_id = 11111111
 
@@ -565,6 +565,16 @@ class TestCreateExamAttempt(ExamsAPITestCase):
         # check to ensure that only one attempt exists for exam and user
         filtered_attempts = ExamAttempt.objects.filter(user_id=user_id, exam_id=exam_id)
         self.assertEqual(len(filtered_attempts), 1)
+
+    def test_exam_with_no_due_date(self):
+        """
+        Test that you can create an attempt for an exam with no due date
+        """
+        exam_id = self.exam.id
+        user_id = self.user.id
+
+        create_exam_attempt(exam_id, user_id)
+        self.assertIsNotNone(ExamAttempt.objects.get(user_id=user_id, exam_id=exam_id))
 
 
 class TestGetExamByContentId(ExamsAPITestCase):

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -126,6 +126,8 @@ CORS_ORIGIN_WHITELIST = (
     LEARNING_MICROFRONTEND_URL,
 )
 
+ALLOWED_HOSTS = ['*']
+
 #####################################################################
 # Lastly, see if the developer has any local overrides.
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):


### PR DESCRIPTION
**JIRA:** [MST-1797](https://2u-internal.atlassian.net/browse/MST-1797)

**Description:** This PR adds a few fixes for issues I found while testing my frontend changes for https://github.com/openedx/frontend-lib-special-exams/pull/88. 

I also included a settings update to allow devstack to communicate with the exams service. This same wildcard is found in `production.py` so there shouldn't be an issue with adding it to `local.py`. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
