### PR TITLE
fix: inconsistent exam response in legacy view

### DIFF
--- a/edx_exams/apps/router/tests/test_views.py
+++ b/edx_exams/apps/router/tests/test_views.py
@@ -235,6 +235,19 @@ class CourseExamAttemptLegacyViewTest(ExamsAPITestCase):
         self.assertEqual(response.status_code, 401)
 
     @mock.patch('edx_exams.apps.router.views.get_student_exam_attempt_data')
+    def test_get_lms_exam_data_failed(self, mock_get_student_exam_attempt_data):
+        """
+        The exam data should be returned from the LMS
+        """
+        mock_get_student_exam_attempt_data.return_value = ('some error', 500)
+
+        response = self.get_api(self.user, self.url)
+        mock_get_student_exam_attempt_data.assert_called_once_with(
+            self.course_id, self.content_id, self.user.lms_user_id
+        )
+        self.assertEqual(response.status_code, 500)
+
+    @mock.patch('edx_exams.apps.router.views.get_student_exam_attempt_data')
     def test_get_lms_exam_data(self, mock_get_student_exam_attempt_data):
         """
         The exam data should be returned from the LMS

--- a/edx_exams/apps/router/tests/test_views.py
+++ b/edx_exams/apps/router/tests/test_views.py
@@ -246,6 +246,9 @@ class CourseExamAttemptLegacyViewTest(ExamsAPITestCase):
                 "exam_type": "a proctored exam",
                 "exam_display_name": "Test Exam",
                 "use_legacy_attempt_api": True,
+            },
+            'active_attempt': {
+                "foo": "bar"
             }
         }, 200)
 
@@ -254,4 +257,5 @@ class CourseExamAttemptLegacyViewTest(ExamsAPITestCase):
             self.course_id, self.content_id, self.user.lms_user_id
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json().get('exam_display_name'), 'Test Exam')
+        self.assertEqual(response.json()['exam']['exam_display_name'], 'Test Exam')
+        self.assertEqual(response.json().get('active_attempt'), None)

--- a/edx_exams/apps/router/views.py
+++ b/edx_exams/apps/router/views.py
@@ -63,8 +63,12 @@ class CourseExamAttemptLegacyView(APIView):
         """
         response_data, status = get_student_exam_attempt_data(course_id, content_id, request.user.lms_user_id)
 
+        # remove active_attempt to keep response consistent with CourseExamAttemptView
+        if 'active_attempt' in response_data:
+            del response_data['active_attempt']
+
         return JsonResponse(
-            data=response_data.get('exam', response_data),
+            data=response_data,
             status=status,
             safe=False,
         )


### PR DESCRIPTION
found a bug when testing against the UI. The legacy view pulls out the exam object and returns the exam as a dict when it should keep it wrapped in an 'exam' key.

current:
```
{
    exam fields
}
```

fixed:
```
{
    'exam': { exam fields }
}
```