### PR TITLE
feat: simplify exam publish

### DIFF
--- a/edx_exams/apps/core/api.py
+++ b/edx_exams/apps/core/api.py
@@ -280,6 +280,13 @@ def get_exam_by_content_id(course_id, content_id):
         return None
 
 
+def get_course_exams(course_id):
+    """
+    Retrieve all active exams for a course
+    """
+    return Exam.objects.filter(course_id=course_id, is_active=True)
+
+
 def get_current_exam_attempt(user_id, exam_id):
     """
     Retrieve the current attempt for a user given an exam


### PR DESCRIPTION
**JIRA:** [MST-1581](https://2u-internal.atlassian.net/browse/MST-1581)

**Description:** Simplifies the exam publish behavior. The original intent was to allow course teams to change exam types from proctored>timed>proctored and end up with the same proctored exam instance throughout. We found this added some unforeseen complexities and we choose not to support it. (see discovery in linked ticket)

Instead, when an exam type changes we create an entirely new version of that exam.