### PR TITLE
build: remove a vestigial cookiecutter artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,9 @@ pii_report
 !django.mo
 !djangojs.po
 !djangojs.mo
-{{cookiecutter.project_name}}/conf/locale/fake*/LC_MESSAGES/*.po
-{{cookiecutter.project_name}}/conf/locale/fake*/LC_MESSAGES/*.mo
-{{cookiecutter.project_name}}/conf/locale/messages.mo
+edx_exams/conf/locale/fake*/LC_MESSAGES/*.po
+edx_exams/conf/locale/fake*/LC_MESSAGES/*.mo
+edx_exams/conf/locale/messages.mo
 
 
 # Mr Developer


### PR DESCRIPTION
(This is a clean-up I noticed during the hackathon.)

The `.gitignore` file had cookiecutter placeholders (somehow?).  It makes "rg" complain when searching the repo:
```
% rg diff.cover
/System/Volumes/Data/root/src/edx/src/edx-exams/.gitignore: line 52: error parsing glob '{{cookiecutter.project_name}}/conf/locale/fake*/LC_MESSAGES/*.po': nested alternate groups are not allowed
/System/Volumes/Data/root/src/edx/src/edx-exams/.gitignore: line 53: error parsing glob '{{cookiecutter.project_name}}/conf/locale/fake*/LC_MESSAGES/*.mo': nested alternate groups are not allowed
/System/Volumes/Data/root/src/edx/src/edx-exams/.gitignore: line 54: error parsing glob '{{cookiecutter.project_name}}/conf/locale/messages.mo': nested alternate groups are not allowed
dev.in
6:diff-cover                # Changeset diff test coverage

dev.txt
44:    # via diff-cover
94:diff-cover==7.5.0
274:    #   diff-cover
375:    #   diff-cover
404:    #   diff-cover
```

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
