### PR TITLE
feat: update exam attempt status after LTI_1P3_PROCTORING_ASSESSMENT_…

### DIFF
--- a/edx_exams/apps/core/api.py
+++ b/edx_exams/apps/core/api.py
@@ -41,6 +41,18 @@ def get_latest_attempt_for_user(user_id):
     return latest_attempt
 
 
+def get_attempt_for_user_with_attempt_number_and_resource_id(user_id, attempt_number, resource_id):
+    """
+    Retrieve an attempt in an exam described by resource_id for a user described by user_id with a particular attempt
+    number described by attempt_number.
+    """
+    return ExamAttempt.get_attempt_for_user_with_attempt_number_and_resource_id(
+        user_id,
+        attempt_number,
+        resource_id,
+    )
+
+
 def update_attempt_status(attempt_id, to_status):
     """
     Function to handle state transition of attempt status. Checks that status transition

--- a/edx_exams/apps/core/models.py
+++ b/edx_exams/apps/core/models.py
@@ -234,6 +234,28 @@ class ExamAttempt(TimeStampedModel):
         except cls.DoesNotExist:
             return True
 
+    @classmethod
+    def get_attempt_for_user_with_attempt_number_and_resource_id(cls, user_id, attempt_number, resource_id):
+        """
+        Retrieve an attempt in an exam described by resource_id for a user described by user_id with a particular
+        attempt number described by attempt_number.
+        """
+        try:
+            attempt = ExamAttempt.objects.get(
+                user_id=user_id,
+                attempt_number=attempt_number,
+                exam__resource_id=resource_id
+            )
+            return attempt
+        except cls.DoesNotExist:
+            return None
+        except cls.MultipleObjectsReturned:
+            log.warning(
+                f'attempt_number={attempt_number} for user_id={user_id} in exam with resource_id={resource_id} is '
+                'associated with multiple attempts.'
+            )
+            return None
+
 
 class CourseExamConfiguration(TimeStampedModel):
     """

--- a/edx_exams/apps/lti/signals/handlers.py
+++ b/edx_exams/apps/lti/signals/handlers.py
@@ -1,8 +1,16 @@
 """
 edX Exams Signal Handlers
 """
+import logging
+
 from django.dispatch import receiver
 from lti_consumer.signals.signals import LTI_1P3_PROCTORING_ASSESSMENT_STARTED
+
+from edx_exams.apps.core.api import get_attempt_for_user_with_attempt_number_and_resource_id, update_attempt_status
+from edx_exams.apps.core.exceptions import ExamIllegalStatusTransition
+from edx_exams.apps.core.statuses import ExamAttemptStatus
+
+log = logging.getLogger(__name__)
 
 
 @receiver(LTI_1P3_PROCTORING_ASSESSMENT_STARTED)
@@ -10,4 +18,36 @@ def assessment_started(sender, **kwargs):  # pylint: disable=unused-argument
     """
     Signal handler for the lti_consumer LTI_1P3_PROCTORING_ASSESSMENT_STARTED signal.
     """
-    print(f"LTI_1P3_PROCTORING_ASSESSMENT_STARTED signal received with kwargs: {kwargs}")
+    user_id = kwargs.get('user_id')
+    attempt_number = kwargs.get('attempt_number')
+    resource_id = kwargs.get('resource_id')
+
+    if not user_id or not attempt_number or not resource_id:
+        log.info(
+            'expected valid values for LTI_1P3_PROCTORING_ASSESSMENT_STARTED signal kwargs but received '
+            f'attempt_number={attempt_number}, user_id={user_id}, and resource_id={resource_id}.'
+        )
+        return
+
+    attempt = get_attempt_for_user_with_attempt_number_and_resource_id(
+        user_id,
+        attempt_number,
+        resource_id,
+    )
+
+    if not attempt:
+        log.info(
+            f'attempt_number={attempt_number} for user_id={user_id} in exam with resource_id={resource_id} is '
+            'not associated with a single attempt.'
+        )
+        return
+
+    try:
+        update_attempt_status(attempt.id, ExamAttemptStatus.ready_to_start)
+    except ExamIllegalStatusTransition:
+        log.info(
+            f'user_id={attempt.user.id} attempted to update attempt_id={attempt.id} in '
+            f'course_id={attempt.exam.course_id} from status={attempt.status} to '
+            f'status={ExamAttemptStatus.ready_to_start}, but this status '
+            f'transition is illegal.'
+        )

--- a/edx_exams/apps/lti/signals/tests/test_handlers.py
+++ b/edx_exams/apps/lti/signals/tests/test_handlers.py
@@ -1,0 +1,163 @@
+"""
+Test signal handlers.
+"""
+import itertools
+import uuid
+from unittest.mock import patch
+
+from ddt import ddt, idata, unpack
+from django.test import TestCase
+
+from edx_exams.apps.api.test_utils.factories import UserFactory
+from edx_exams.apps.core.models import Exam, ExamAttempt, ProctoringProvider
+from edx_exams.apps.core.statuses import ExamAttemptStatus
+from edx_exams.apps.lti.signals.handlers import assessment_started
+
+
+@ddt
+class TestAssessmentStarted(TestCase):
+    """
+    Test the assessment_started signal handler.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.user = UserFactory(username='test', is_active=True, is_staff=False)
+        self.user.set_password('password')
+        self.user.save()
+
+        self.test_provider = ProctoringProvider.objects.create(
+            name='test_provider',
+            verbose_name='testing provider',
+            lti_configuration_id='123456789',
+            tech_support_phone='1118976309',
+            tech_support_email='test@example.com',
+        )
+
+        self.course_id = 'course-v1:edx+test+f19'
+        self.content_id = '11111111'
+
+        self.exam = Exam.objects.create(
+            resource_id=str(uuid.uuid4()),
+            course_id=self.course_id,
+            provider=self.test_provider,
+            content_id=self.content_id,
+            exam_name='test_exam',
+            exam_type='proctored',
+            time_limit_mins=30,
+            due_date='2021-07-01 00:00:00',
+            hide_after_due=False,
+            is_active=True
+        )
+
+        self.attempt = ExamAttempt.objects.create(
+            user=self.user,
+            exam=self.exam,
+            attempt_number=1111111,
+            status=ExamAttemptStatus.created,
+            start_time=None,
+            allowed_time_limit_mins=None,
+        )
+
+    def test_assessment_started_updated_attempt(self):
+        """
+        Test that the assessment_started signal handler updates the attempt described by the kwargs to the
+        ready_to_start state.
+        """
+        kwargs = {
+            'user_id': self.user.id,
+            'attempt_number': self.attempt.attempt_number,
+            'resource_id': self.exam.resource_id,
+        }
+
+        assessment_started(None, **kwargs)
+
+        self.attempt.refresh_from_db()
+
+        self.assertEqual(self.attempt.status, ExamAttemptStatus.ready_to_start)
+
+    @patch('edx_exams.apps.lti.signals.handlers.update_attempt_status')
+    @idata(itertools.product([1, None], [1, None], [None, uuid.uuid4()]))
+    @unpack
+    def test_assessment_started_invalid_kwargs(self, user_id, attempt_number, resource_id, mock_update_attempt_status):
+        """
+        Test that the assessment_started signal handler does not update call update_attempt_status when the
+        LTI_1P3_PROCTORING_ASSESSMENT_STARTED kwargs are invalid (i.e. falsey).
+        """
+        kwargs = {
+            'user_id': user_id,
+            'attempt_number': attempt_number,
+            'resource_id': resource_id,
+        }
+
+        assessment_started(None, **kwargs)
+
+        assert not mock_update_attempt_status.called
+
+    @patch('edx_exams.apps.lti.signals.handlers.update_attempt_status')
+    def test_assessment_started_no_attempt(self, mock_update_attempt_status):
+        """
+        Test that the assessment_started signal handler does not update call update_attempt_status for the attempt
+        described by the kwargs to the ready_to_start state when there is no attempt described by the kwargs.
+        """
+        kwargs = {
+            'user_id': self.user.id,
+            'attempt_number': 100,
+            'resource_id': self.exam.resource_id,
+        }
+
+        assessment_started(None, **kwargs)
+
+        assert not mock_update_attempt_status.called
+
+    @patch('edx_exams.apps.lti.signals.handlers.update_attempt_status')
+    def test_assessment_started_multiple_attempts(self, mock_update_attempt_status):
+        """
+        Test that the assessment_started signal handler does not update the attempts described by the kwargs to the
+        ready_to_start state when there is more than one attempt described by the kwargs.
+        """
+        other_attempt = ExamAttempt.objects.create(
+            user=self.user,
+            exam=self.exam,
+            attempt_number=1111111,
+            status=ExamAttemptStatus.created,
+            start_time=None,
+            allowed_time_limit_mins=None,
+        )
+
+        kwargs = {
+            'user_id': self.user.id,
+            'attempt_number': self.attempt.attempt_number,
+            'resource_id': str(uuid.uuid4()),
+        }
+
+        assessment_started(None, **kwargs)
+
+        self.attempt.refresh_from_db()
+
+        # Both attempt's attempt status should remain unchanged because the kwargs refer to more than one attempt.
+        assert not mock_update_attempt_status.called
+        self.assertEqual(self.attempt.status, ExamAttemptStatus.created)
+        self.assertEqual(other_attempt.status, ExamAttemptStatus.created)
+
+    def test_assessment_started_illegal_transition(self):
+        """
+        Test that the assessment_started signal handler does not update the attempt described by the kwargs to the
+        ready_to_start state when it would be an illegal status transition.
+        """
+        self.attempt.status = ExamAttemptStatus.submitted
+        self.attempt.save()
+
+        kwargs = {
+            'user_id': self.user.id,
+            'attempt_number': self.attempt.attempt_number,
+            'resource_id': self.exam.resource_id,
+        }
+
+        assessment_started(None, **kwargs)
+
+        self.attempt.refresh_from_db()
+
+        # The attempt status should remain unchanged because the requested transition is illegal.
+        self.assertEqual(self.attempt.status, ExamAttemptStatus.submitted)

--- a/edx_exams/apps/lti/tests/test_views.py
+++ b/edx_exams/apps/lti/tests/test_views.py
@@ -18,7 +18,7 @@ from edx_exams.apps.lti.utils import get_lti_root
 @patch('edx_exams.apps.lti.views.get_lti_1p3_launch_start_url', return_value='https://www.example.com')
 class LtiStartProctoringTestCase(ExamsAPITestCase):
     """
-    Tests start_proctoring view
+    Test start_proctoring view
     """
 
     def setUp(self):
@@ -66,7 +66,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def get_start_proctoring_url(self, attempt_id):
         """
-        Returns the URL to the start_proctoring view.
+        Return the URL to the start_proctoring view.
 
         Parameters:
             * attempt_id: the id field of the attempt object
@@ -75,7 +75,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def test_start_proctoring_launch_data(self, mock_get_lti_launch_url):
         """
-        Tests that the instance of Lti1p3LaunchData sent as an argument to get_lti_1p3_launch_start_url
+        Test that the instance of Lti1p3LaunchData sent as an argument to get_lti_1p3_launch_start_url
         contains the correct data.
         """
         headers = self.build_jwt_headers(self.user)
@@ -104,7 +104,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def test_start_proctoring_updated_attempt(self, mock_get_lti_launch_url):  # pylint: disable=unused-argument
         """
-        Tests that calling the start_proctoring view updates the appropriate attempt to the
+        Test that calling the start_proctoring view updates the appropriate attempt to the
         'download software clicked' status.
         """
         headers = self.build_jwt_headers(self.user)
@@ -117,7 +117,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def test_start_proctoring_no_attempt(self, mock_get_lti_launch_url):  # pylint: disable=unused-argument
         """
-        Tests that a 400 response is returned when calling the start_proctoring view with an attempt_id
+        Test that a 400 response is returned when calling the start_proctoring view with an attempt_id
         that does not exist.
         """
         url = self.get_start_proctoring_url(1000)
@@ -129,7 +129,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def test_start_proctoring_illegal_transition(self, mock_get_lti_launch_url):  # pylint: disable=unused-argument
         """
-        Tests that a 403 response is returned when calling the start_proctoring view requests an illegal status
+        Test that a 403 response is returned when calling the start_proctoring view requests an illegal status
         transition for the attempt_id.
         """
         self.attempt.status = ExamAttemptStatus.submitted
@@ -142,7 +142,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
 
     def test_start_proctoring_unauthorized_user(self, mock_get_lti_launch_url):  # pylint: disable=unused-argument
         """
-        Tests that a 403 response is returned when calling the start_proctoring view with an attempt_id
+        Test that a 403 response is returned when calling the start_proctoring view with an attempt_id
         that does not belong to the calling user.
         """
         other_user = UserFactory()


### PR DESCRIPTION
**JIRA:** [MST-1843](https://2u-internal.atlassian.net/browse/MST-1843)

**Description:** This commits adds behavior to update a learner's exam attempt status to the `ready_to_start` status when the `LTI_1P3_PROCTORING_ASSESSMENT_STARTED` signal is received.

**Author concerns:** None.
**Dependencies:** None.

**Installation instructions:** Please follow the instructions in [Local Development and LTI Configuration](https://2u-internal.atlassian.net/wiki/spaces/PT/pages/256737327/Local+Development+and+LTI+Configuration) to set up your environment.

**Testing instructions:**

**Testing instructions:**

1. Create an `ExamAttempt` with the `created` status.
2. Open the Django shell from the command line. `python manage.py shell`
3. Import and run the signal.
```
from django.contrib.auth import get_user_model
from lti_consumer.signals.signals import LTI_1P3_ASSESSMENT_STARTED
from edx_exams.apps.core.models import Exam, ExamAttempt

user_model = get_user_model()
user = user_model.objects.get(username='edx')

exam = Exam.objects.get(id=<id>)
attempt_number = ExamAttempt.objects.get(id=<id>

LTI_1P3_PROCTORING_ASSESSMENT_STARTED.send(sender=None, attempt_number=attempt.attempt_number, resource_id=exam.resource_id, user_id=user.id)
```
4. Verify that the `ExamAttempt` has transitioned to the `ready_to_start` state and that you see the corresponding logs in the console.
5. Create additional `ExamAttempts` to verify error cases by re-sending the signal with the appropriate arguments.


**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
