### PR TITLE
feat: add total time to exam response

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1271,6 +1271,7 @@ class CourseExamAttemptViewTest(ExamsAPITestCase):
         expected_data['type'] = self.exam.exam_type
         expected_data['is_proctored'] = exam_type_class.is_proctored
         expected_data['is_practice_exam'] = exam_type_class.is_practice
+        expected_data['total_time'] = self.exam.time_limit_mins
         expected_data['backend'] = self.exam.provider.verbose_name
         expected_data['attempt'] = {}
 

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -594,6 +594,8 @@ class CourseExamAttemptView(ExamsAPIView):
         serialized_exam['type'] = exam.exam_type
         serialized_exam['is_proctored'] = exam_type_class.is_proctored
         serialized_exam['is_practice_exam'] = exam_type_class.is_practice
+        # total time is equivalent to time_limit_mins for now because allowances are not yet supported
+        serialized_exam['total_time'] = exam.time_limit_mins
         # timed exams will have None as a backend
         serialized_exam['backend'] = exam.provider.verbose_name if exam.provider is not None else None
         exam_attempt = get_current_exam_attempt(request.user.id, exam.id)


### PR DESCRIPTION
**JIRA:** [MST-1836](https://2u-internal.atlassian.net/browse/MST-1836)

**Description:** The frontend for exams expects a `total_time` field to be available for use in the entrance interstitials. Previously, this field had been left out of the backend so the interstitials did not appear as expected. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
