### PR TITLE
feat: add list attempt api

### DIFF
--- a/edx_exams/apps/api/serializers.py
+++ b/edx_exams/apps/api/serializers.py
@@ -138,3 +138,34 @@ class StudentAttemptSerializer(serializers.ModelSerializer):
             'attempt_id', 'attempt_status', 'course_id', 'exam_type',
             'exam_display_name', 'exam_url_path', 'time_remaining_seconds'
         )
+
+
+class InstructorViewAttemptSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ExamAttempt model containing fields needed for the instructor view
+    """
+
+    # directly from the ExamAttempt Model
+    attempt_id = serializers.IntegerField(source='id')
+    attempt_status = serializers.CharField(source='status')
+    start_time = DateTimeField(format=None)
+    end_time = DateTimeField(format=None)
+    allowed_time_limit_mins = serializers.IntegerField()
+
+    # fields based on the ExamModel
+    exam_type = serializers.CharField(source='exam.exam_type')
+    exam_display_name = serializers.CharField(source='exam.exam_name')
+
+    # fields based on the UserModel
+    username = serializers.CharField(source='user.username')
+
+    class Meta:
+        """
+        Meta Class
+        """
+        model = ExamAttempt
+
+        fields = (
+            'attempt_id', 'attempt_status', 'start_time', 'end_time',
+            'allowed_time_limit_mins', 'exam_type', 'exam_display_name', 'username'
+        )

--- a/edx_exams/apps/api/test_utils/factories.py
+++ b/edx_exams/apps/api/test_utils/factories.py
@@ -2,9 +2,14 @@
 Factories for exams tests
 """
 
+import datetime
+
 import factory
 from django.contrib.auth import get_user_model
 from factory.django import DjangoModelFactory
+
+from edx_exams.apps.core.models import CourseExamConfiguration, Exam, ExamAttempt, ProctoringProvider
+from edx_exams.apps.core.statuses import ExamAttemptStatus
 
 
 class UserFactory(DjangoModelFactory):
@@ -15,16 +20,74 @@ class UserFactory(DjangoModelFactory):
     class Meta:
         model = get_user_model()
         django_get_or_create = (
-            "email",
-            "username",
+            'email',
+            'username',
         )
 
-    _DEFAULT_PASSWORD = "test"
+    _DEFAULT_PASSWORD = 'test'
 
-    username = factory.Sequence("user{}".format)
-    email = factory.Sequence("user+test+{}@edx.org".format)
-    password = factory.PostGenerationMethodCall("set_password", _DEFAULT_PASSWORD)
-    first_name = factory.Sequence("User{}".format)
-    last_name = "Test"
+    username = factory.Sequence('user{}'.format)
+    email = factory.Sequence('user+test+{}@edx.org'.format)
+    password = factory.PostGenerationMethodCall('set_password', _DEFAULT_PASSWORD)
+    first_name = factory.Sequence('User{}'.format)
+    last_name = 'Test'
     is_superuser = False
     is_staff = False
+
+
+class ProctoringProviderFactory(DjangoModelFactory):
+    """
+    Factory to create proctoring providers to be used in other unit tests
+    """
+    class Meta:
+        model = ProctoringProvider
+
+    name = factory.Sequence('test_provider_{}'.format)
+    verbose_name = factory.Sequence('Test Provider {}'.format)
+    lti_configuration_id = factory.Sequence('11{}'.format)
+    tech_support_phone = '1118976309'
+    tech_support_email = 'test@example.com'
+
+
+class CourseExamConfigurationFactory(DjangoModelFactory):
+    """
+    Factory to create course exam configurations to be used in other unit tests
+    """
+    class Meta:
+        model = CourseExamConfiguration
+
+    course_id = 'course-v1:edX+Test+Test_Course'
+    provider = factory.SubFactory(ProctoringProviderFactory)
+    allow_opt_out = False
+
+
+class ExamFactory(DjangoModelFactory):
+    """
+    Factory to create exams to be used in other unit tests
+    """
+    class Meta:
+        model = Exam
+
+    resource_id = str(factory.Sequence('resource{}'.format))
+    course_id = 'course-v1:edX+Test+Test_Course'
+    content_id = factory.Sequence('block-v1:edX+test+2023+type@sequential+block@1111111111{}'.format)
+    provider = factory.SubFactory(ProctoringProviderFactory)
+    exam_name = factory.Sequence('exam{}'.format)
+    exam_type = 'proctored'
+    time_limit_mins = 30
+    due_date = datetime.datetime.now() + datetime.timedelta(days=1)
+
+
+class ExamAttemptFactory(DjangoModelFactory):
+    """
+    Factory to create exam attempts to be used in other unit tests
+    """
+    class Meta:
+        model = ExamAttempt
+
+    exam = factory.SubFactory(ExamFactory)
+    user = factory.SubFactory(UserFactory)
+    attempt_number = 1
+    status = ExamAttemptStatus.created
+    start_time = None
+    allowed_time_limit_mins = 30

--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -8,6 +8,7 @@ from edx_exams.apps.api.v1.views import (
     CourseExamsView,
     CourseProviderSettingsView,
     ExamAccessTokensView,
+    ExamAttemptListView,
     ExamAttemptView,
     LatestExamAttemptView,
     ProctoringProvidersView
@@ -17,31 +18,54 @@ from edx_exams.apps.core.constants import CONTENT_ID_PATTERN, COURSE_ID_PATTERN,
 app_name = 'v1'
 
 urlpatterns = [
-    re_path(fr'exams/course_id/{COURSE_ID_PATTERN}',
-            CourseExamsView.as_view(),
-            name='exams-course_exams'),
-    re_path(fr'configs/course_id/{COURSE_ID_PATTERN}',
-            CourseExamConfigurationsView.as_view(),
-            name='course-exam-config'),
-    re_path(r'^providers?$',
-            ProctoringProvidersView.as_view(),
-            name='proctoring-providers-list',),
-    re_path(fr'access_tokens/exam_id/{EXAM_ID_PATTERN}',
-            ExamAccessTokensView.as_view(),
-            name='exam-access-tokens'),
-    path('exams/attempt/<int:attempt_id>',
-         ExamAttemptView.as_view(),
-         name='exams-attempt',),
-    path('exams/attempt',
-         ExamAttemptView.as_view(),
-         name='exams-attempt',),
-    path('exams/attempt/latest',
-         LatestExamAttemptView.as_view(),
-         name='exams-attempt-latest',),
-    re_path(fr'student/exam/attempt/course_id/{COURSE_ID_PATTERN}/content_id/{CONTENT_ID_PATTERN}',
-            CourseExamAttemptView.as_view(),
-            name='student-course_exam_attempt'),
-    re_path(fr'exam/provider_settings/course_id/{COURSE_ID_PATTERN}/exam_id/{EXAM_ID_PATTERN}',
-            CourseProviderSettingsView.as_view(),
-            name='exam-provider-settings'),
+    re_path(
+        fr'exams/course_id/{COURSE_ID_PATTERN}',
+        CourseExamsView.as_view(),
+        name='exams-course_exams'
+    ),
+    re_path(
+        fr'configs/course_id/{COURSE_ID_PATTERN}',
+        CourseExamConfigurationsView.as_view(),
+        name='course-exam-config'
+    ),
+    re_path(
+        r'^providers?$',
+        ProctoringProvidersView.as_view(),
+        name='proctoring-providers-list',
+    ),
+    re_path(
+        fr'access_tokens/exam_id/{EXAM_ID_PATTERN}',
+        ExamAccessTokensView.as_view(),
+        name='exam-access-tokens'
+    ),
+    path(
+        'exams/attempt/<int:attempt_id>',
+        ExamAttemptView.as_view(),
+        name='exams-attempt',
+    ),
+    path(
+        'exams/attempt',
+        ExamAttemptView.as_view(),
+        name='exams-attempt',
+    ),
+    path(
+        'exams/attempt/list',
+        ExamAttemptListView.as_view(),
+        name='exams-attempt-list'
+    ),
+    path(
+        'exams/attempt/latest',
+        LatestExamAttemptView.as_view(),
+        name='exams-attempt-latest',
+    ),
+    re_path(
+        fr'student/exam/attempt/course_id/{COURSE_ID_PATTERN}/content_id/{CONTENT_ID_PATTERN}',
+        CourseExamAttemptView.as_view(),
+        name='student-course_exam_attempt'
+    ),
+    re_path(
+        fr'exam/provider_settings/course_id/{COURSE_ID_PATTERN}/exam_id/{EXAM_ID_PATTERN}',
+        CourseProviderSettingsView.as_view(),
+        name='exam-provider-settings'
+    ),
 ]

--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -8,8 +8,8 @@ from edx_exams.apps.api.v1.views import (
     CourseExamsView,
     CourseProviderSettingsView,
     ExamAccessTokensView,
-    ExamAttemptListView,
     ExamAttemptView,
+    InstructorAttemptsListView,
     LatestExamAttemptView,
     ProctoringProvidersView
 )
@@ -49,14 +49,14 @@ urlpatterns = [
         name='exams-attempt',
     ),
     path(
-        'exams/attempt/list',
-        ExamAttemptListView.as_view(),
-        name='exams-attempt-list'
-    ),
-    path(
         'exams/attempt/latest',
         LatestExamAttemptView.as_view(),
         name='exams-attempt-latest',
+    ),
+    path(
+        'instructor_view/attempts',
+        InstructorAttemptsListView.as_view(),
+        name='instructor-attempts-list'
     ),
     re_path(
         fr'student/exam/attempt/course_id/{COURSE_ID_PATTERN}/content_id/{CONTENT_ID_PATTERN}',

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -10,12 +10,18 @@ from edx_api_doc_tools import path_parameter, schema
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework.generics import ListAPIView
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from token_utils.api import sign_token_for
 
 from edx_exams.apps.api.permissions import StaffUserOrReadOnlyPermissions, StaffUserPermissions
-from edx_exams.apps.api.serializers import ExamSerializer, ProctoringProviderSerializer, StudentAttemptSerializer
+from edx_exams.apps.api.serializers import (
+    ExamSerializer,
+    InstructorViewAttemptSerializer,
+    ProctoringProviderSerializer,
+    StudentAttemptSerializer
+)
 from edx_exams.apps.api.v1 import ExamsAPIView
 from edx_exams.apps.core.api import (
     check_if_exam_timed_out,
@@ -24,6 +30,7 @@ from edx_exams.apps.core.api import (
     get_course_exams,
     get_current_exam_attempt,
     get_exam_attempt_time_remaining,
+    get_exam_attempts,
     get_exam_by_content_id,
     get_latest_attempt_for_user,
     get_provider_by_exam_id,
@@ -552,6 +559,44 @@ class ExamAttemptView(ExamsAPIView):
 
         data = {'exam_attempt_id': exam_attempt_id}
         return Response(data)
+
+
+class ExamAttemptListView(ExamsAPIView):
+    """
+    Endpoint for listing exam attempts. Used to provide data for the instructor
+    facing exam dashboard.
+
+    /exams/attempt?exam_id=<exam_id>
+
+    Supports:
+        HTTP GET: List student exam attempts.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (StaffUserPermissions,)
+
+    def get(self, request):
+        """
+        HTTP GET handler to fetch all exam attempt data for a given exam.
+
+        Query Parameters:
+            exam_id: Unique identifier for an exam.
+
+        Returns:
+            A Response object containing all `ExamAttempt` data.
+        """
+        exam_id = request.query_params.get('exam_id', None)
+
+        # instructor serializer will follow FK relationships to get user and
+        # exam fields. This list is potentially large so use
+        # select related to avoid n+1 issues.
+        attempts = get_exam_attempts(exam_id).select_related('exam', 'user')
+
+        paginator = LimitOffsetPagination()
+        paginated_attempts = paginator.paginate_queryset(attempts, request)
+        return paginator.get_paginated_response(
+            InstructorViewAttemptSerializer(paginated_attempts, many=True).data
+        )
 
 
 class CourseExamAttemptView(ExamsAPIView):

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -561,12 +561,12 @@ class ExamAttemptView(ExamsAPIView):
         return Response(data)
 
 
-class ExamAttemptListView(ExamsAPIView):
+class InstructorAttemptsListView(ExamsAPIView):
     """
     Endpoint for listing exam attempts. Used to provide data for the instructor
     facing exam dashboard.
 
-    /exams/attempt?exam_id=<exam_id>
+    /instructor_view/attempts?exam_id=<exam_id>
 
     Supports:
         HTTP GET: List student exam attempts.

--- a/edx_exams/apps/core/api.py
+++ b/edx_exams/apps/core/api.py
@@ -22,6 +22,13 @@ from edx_exams.apps.core.statuses import ExamAttemptStatus
 log = logging.getLogger(__name__)
 
 
+def get_exam_attempts(exam_id):
+    """
+    Return all attempts for an exam
+    """
+    return ExamAttempt.objects.filter(exam_id=exam_id).order_by('-created')
+
+
 def get_attempt_by_id(attempt_id):
     """
     Return an attempt by id

--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -80,6 +80,10 @@ MIDDLEWARE = (
     'edx_exams.apps.router.middleware.ExamRequestMiddleware'
 )
 
+REST_FRAMEWORK = {
+    'PAGE_SIZE': 100
+}
+
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_HEADERS = corsheaders_default_headers + (


### PR DESCRIPTION
**JIRA:** [MST-1891](https://2u-internal.atlassian.net/browse/MST-1891)

**Description:** Adds a new endpoint to list attempts filtered by an exam id. This will drive the new 'instructor dashboard' component for exam. I expect this endpoint will include additional filter params beyond just exam_id once we add the search feature.

Using limit offset pagination allows the UI to decide it's own page size by setting the limit parameter.

Example `/instructor_view/attempts?exam_id=28&limit=20`


