### PR TITLE
fix: add passed_due_date key to response from CourseExamAttemptView GET endpoint

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1355,7 +1355,7 @@ class CourseExamAttemptViewTest(ExamsAPITestCase):
             exam_name='test_exam',
             exam_type='proctored',
             time_limit_mins=30,
-            due_date='2040-07-01T00:00:00Z',
+            due_date=timezone.now() + timedelta(days=1),
             hide_after_due=False,
             is_active=True
         )
@@ -1404,6 +1404,7 @@ class CourseExamAttemptViewTest(ExamsAPITestCase):
         expected_data['is_practice_exam'] = exam_type_class.is_practice
         expected_data['total_time'] = self.exam.time_limit_mins
         expected_data['backend'] = self.exam.provider.verbose_name
+        expected_data['passed_due_date'] = False
         expected_data['attempt'] = {}
 
         response = self.get_api(self.user, self.course_id, self.content_id)

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -34,6 +34,7 @@ from edx_exams.apps.core.api import (
     get_exam_by_content_id,
     get_latest_attempt_for_user,
     get_provider_by_exam_id,
+    is_exam_passed_due,
     update_attempt_status
 )
 from edx_exams.apps.core.exam_types import get_exam_type
@@ -661,6 +662,8 @@ class CourseExamAttemptView(ExamsAPIView):
         serialized_exam['total_time'] = exam.time_limit_mins
         # timed exams will have None as a backend
         serialized_exam['backend'] = exam.provider.verbose_name if exam.provider is not None else None
+
+        serialized_exam['passed_due_date'] = is_exam_passed_due(serialized_exam)
         exam_attempt = get_current_exam_attempt(request.user.id, exam.id)
         if exam_attempt is not None:
             exam_attempt = check_if_exam_timed_out(exam_attempt)

--- a/edx_exams/apps/core/api.py
+++ b/edx_exams/apps/core/api.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 
 import pytz
 from django.conf import settings
-from django.utils import timezone
+from django.utils import dateparse, timezone
 from opaque_keys.edx.keys import CourseKey, UsageKey
 
 from edx_exams.apps.core.exam_types import OnboardingExamType, PracticeExamType, get_exam_type
@@ -333,3 +333,19 @@ def get_provider_by_exam_id(exam_id):
         return exam.provider
     except Exam.DoesNotExist:
         return None
+
+
+def is_exam_passed_due(exam):
+    """
+    Return whether the exam is passed due.
+
+    Parameters:
+        * exam: a serialized representation of the exam
+    """
+    due_date = exam['due_date']
+
+    # In certain cases, an exam may not have a due date. In this case, the exam is never passed due.
+    if due_date:
+        due_date = dateparse.parse_datetime(due_date)
+        return due_date <= datetime.now(pytz.UTC)
+    return False

--- a/edx_exams/apps/core/tests/test_api.py
+++ b/edx_exams/apps/core/tests/test_api.py
@@ -22,6 +22,7 @@ from edx_exams.apps.core.api import (
     get_exam_by_content_id,
     get_exam_url_path,
     get_latest_attempt_for_user,
+    is_exam_passed_due,
     update_attempt_status
 )
 from edx_exams.apps.core.exceptions import (
@@ -761,3 +762,45 @@ class TestGetAttemptForUserWithAttemptNumberAndResourceId(ExamsAPITestCase):
         )
 
         self.assertIsNone(attempt)
+
+
+class TestIsExamPassedDue(ExamsAPITestCase):
+    """
+    Test the is_exam_passed_due API function.
+    """
+    def test_passed_due_equal(self):
+        """
+        Test that is_exam_passed_due returns True when the due date is equal to the current date (i.e. now).
+        """
+        with freeze_time(timezone.now()):
+            exam = {'due_date': str(timezone.now())}
+
+            self.assertTrue(is_exam_passed_due(exam))
+
+    def test_passed_due_less_than(self):
+        """
+        Test that is_exam_passed_due returns True when the due date is less than the current date (i.e. in the past).
+        """
+        with freeze_time(timezone.now()):
+            exam = {'due_date': str(timezone.now() - timedelta(hours=1))}
+
+            self.assertTrue(is_exam_passed_due(exam))
+
+    def test_not_passed_due_greater_than(self):
+        """
+        Test that is_exam_passed_due returns False when the due date is greater than the current date
+        (i.e. in the future).
+        """
+        with freeze_time(timezone.now()):
+            exam = {'due_date': str(timezone.now() + timedelta(hours=1))}
+
+            self.assertFalse(is_exam_passed_due(exam))
+
+    def test_not_passed_due_no_due_date(self):
+        """
+        Test that is_exam_passed_due returns False when the due date does not exist.
+        """
+        with freeze_time(timezone.now()):
+            exam = {'due_date': None}
+
+            self.assertFalse(is_exam_passed_due(exam))


### PR DESCRIPTION
**JIRA:** [MST-1869](https://2u-internal.atlassian.net/browse/MST-1869)

**Description:** 

The proctoring frontend hosted by the [frontend-lib-special-exams](https://github.com/openedx/frontend-lib-special-exams) frontend library is meant to block a learner from starting an exam that is passed due. The frontend relies on a key returned by the backend called `passed_due_date` to [determine whether or not to block access to the exam](https://github.com/openedx/frontend-lib-special-exams/blob/6b2ba0513624eb6e6fac00c38050edaf7c8a6ebe/src/helpers.js#L10C1-L16). The frontend calls `edx-exams's` `CourseExamAttemptView` GET endpoint to get information about the exam and the attempt, and it expects this key to be present in the response.

However, this key was missing, which allowed learners to attempt to start the exam in the browser. Even though the backend correctly prevented them from starting the exam, the experience was confusing. This commit fixes this bug by sending a `passed_due_date` key in the response.

<img width="1081" alt="Screenshot 2023-05-19 at 8 08 15 AM" src="https://github.com/edx/edx-exams/assets/11871801/47308b71-31cd-4742-8dcb-17cd1bf3278d">

<img width="1092" alt="Screenshot 2023-05-19 at 8 08 55 AM" src="https://github.com/edx/edx-exams/assets/11871801/a2c16a60-f00a-45b0-928a-0f117203d412">

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:**

1. Create a passed due proctored exam in Studio using an LTI provider.
2. Visit the exam as a verified learner.
3. Verify that the exam expired interstitial is displayed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
