### PR TITLE
feat: add context to launch data

### DIFF
--- a/edx_exams/apps/lti/tests/test_views.py
+++ b/edx_exams/apps/lti/tests/test_views.py
@@ -285,6 +285,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
             message_type='LtiStartProctoring',
             proctoring_launch_data=expected_proctoring_launch_data,
             context_id=self.course_id,
+            context_label=self.content_id,
         )
 
         mock_get_lti_launch_url.assert_called_with(expected_launch_data)

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -183,6 +183,7 @@ def start_proctoring(request, attempt_id):
         message_type='LtiStartProctoring',
         proctoring_launch_data=proctoring_launch_data,
         context_id=exam.course_id,
+        context_label=exam.content_id,
     )
 
     return redirect(get_lti_1p3_launch_start_url(launch_data))


### PR DESCRIPTION
**JIRA:** MST-1932

**Description:** This PR adds context (content url and MFE url as context_label and context_title respectively) to the launch data so that it can be used to redirect once an LTI proctored exam is started.

**Dependencies:** Blocked by https://github.com/openedx/xblock-lti-consumer/pull/382

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
