### PR TITLE
Modify local Kafka settings.

### DIFF
--- a/edx_exams/settings/devstack.py
+++ b/edx_exams/settings/devstack.py
@@ -53,6 +53,8 @@ JWT_AUTH.update({
 
 LMS_ROOT_URL = 'http://edx.devstack.lms:18000'
 
+# EVENT BUS
+
 EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
 EVENT_BUS_CONSUMER = 'edx_event_bus_kafka.KafkaEventConsumer'
 EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -135,11 +135,19 @@ ALLOWED_HOSTS = ['*']
 if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
     from .private import *  # pylint: disable=import-error
 
+# EVENT BUS
+# Below are Django settings related to setting up the Open edX event bus.
+# Because the event bus requires a Docker based networking layer, as included in devstack, the event bus does not work
+# outside of a Docker container. Therefore, the settings related to networking are set to None, because this file is
+# used for the local application server. However, because these local Django settings are also used by Tutor, we include
+# sensible values for non-network related settings. Tutor users can override these settings when setting up the event
+# bus, including the network-related settings.
+
 EVENT_BUS_PRODUCER = 'edx_event_bus_kafka.create_producer'
 EVENT_BUS_CONSUMER = 'edx_event_bus_kafka.KafkaEventConsumer'
-EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = 'http://edx.devstack.schema-registry:8081'
-EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = 'edx.devstack.kafka:29092'
 EVENT_BUS_TOPIC_PREFIX = 'dev'
+EVENT_BUS_KAFKA_SCHEMA_REGISTRY_URL = None
+EVENT_BUS_KAFKA_BOOTSTRAP_SERVERS = None
 
 # The EVENT_BUS_PRODUCER_CONFIG Django setting introduced in openedx-events 8.6.0 does not work properly.
 # In order to unblock development, EVENT_BUS_PRODUCER_CONFIG should be set to the empty object. Signal handlers


### PR DESCRIPTION
**JIRA:** None.

**Description:**

This commit set Django settings in the local settings file for event bus networking settings to to `None`. These settings are used by the local application server. This change is necessary because the event bus does not work outside of a Docker container, because the event bus is run through the devstack networking layer, which is inaccessible by the local application server. Because the local settings file is also used by Tutor, only the networking related settings are set to `None`. The remaining settings are left as-is, because they are sensible defaults. Tutor uses can override these settings as need be.

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:** None.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
