### PR TITLE
fix: end assessment launch

### DIFF
--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -292,7 +292,7 @@ def end_assessment(request, attempt_id):
 
     exam = attempt.exam
     resource_link_id = exam.resource_id
-    end_assessment_return = get_end_assessment_return(request.user.anonymous_user_id, resource_link_id)
+    end_assessment_return = get_end_assessment_return(request.user.id, resource_link_id)
 
     # If end_assessment_return was provided by the Proctoring Tool, and end_assessment was True, then the Assessment
     # Platform MUST send an End Assessment message to the Proctoring Tool. Otherwise, the Assessment Platform can


### PR DESCRIPTION
**JIRA:** [MST-2159](https://2u-internal.atlassian.net/browse/MST-2159?atlOrigin=eyJpIjoiZjdkY2YzMThiMzhkNGNiNWFlMDhkYzY1M2ZhNzQ2NGYiLCJwIjoiaiJ9)

**Description:** The user_id passed to this function is used to lookup the initial launch data which is based on the user's database id instead of their external/anonymous id. 

**Author concerns:** Pretty sure this is the issue but hitting some problems with the IMS tools locally so I can't validate. Going to try this out on stage where things are working.
