### PR TITLE
feat: roster endpoint POC

### DIFF
--- a/edx_exams/apps/lti/tests/test_views.py
+++ b/edx_exams/apps/lti/tests/test_views.py
@@ -640,6 +640,9 @@ class LtiInstructorLaunchTest(ExamsAPITestCase):
                 resource_link_id=self.exam.resource_id,
                 external_user_id=str(self.course_staff_user.anonymous_user_id),
                 context_id=self.exam.course_id,
+                custom_parameters={
+                    'roster_url': 'http://test.exams:18740/lti/exam/1/instructor_tool/roster',
+                }
             )
         )
         self.assertEqual(response.status_code, 302)

--- a/edx_exams/apps/lti/urls.py
+++ b/edx_exams/apps/lti/urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path('end_assessment/<int:attempt_id>', views.end_assessment, name='end_assessment'),
     path('start_proctoring/<int:attempt_id>', views.start_proctoring, name='start_proctoring'),
     path('exam/<int:exam_id>/instructor_tool', views.launch_instructor_tool, name='instructor_tool'),
+    path('exam/<int:exam_id>/instructor_tool/roster', views.exam_roster, name='exam_roster'),
 ]

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -7,9 +7,12 @@ import logging
 from decimal import Decimal
 from urllib.parse import urljoin
 
+from django.conf import settings
 from django.contrib.auth import login
+from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from lti_consumer.api import get_end_assessment_return, get_lti_1p3_launch_start_url
@@ -25,6 +28,7 @@ from rest_framework.response import Response
 from edx_exams.apps.core.api import (
     get_attempt_by_id,
     get_attempt_for_user_with_attempt_number_and_resource_id,
+    get_exam_attempts,
     get_exam_by_id,
     get_exam_url_path,
     update_attempt_status
@@ -337,6 +341,7 @@ def end_assessment(request, attempt_id):
 @authentication_classes((JwtAuthentication,))
 @permission_classes((IsAuthenticated,))
 def launch_instructor_tool(request, exam_id):
+    # pragma: no cover
     """
     View to initiate an LTI launch of the Instructor Tool for an exam.
     """
@@ -360,6 +365,37 @@ def launch_instructor_tool(request, exam_id):
         resource_link_id=exam.resource_id,
         external_user_id=str(user.anonymous_user_id),
         context_id=exam.course_id,
+        custom_parameters={
+            'roster_url': settings.LTI_API_BASE + reverse('lti:exam_roster', kwargs={'exam_id': exam.id}),
+        }
     )
 
+    # user is authenticated via JWT so use that to create a
+    # session with this service's authentication backend
+    request.user.backend = EDX_OAUTH_BACKEND
+    login(request, user)
+
     return redirect(get_lti_1p3_launch_start_url(launch_data))
+
+
+@csrf_exempt
+@require_http_methods(['GET'])
+def exam_roster(request, exam_id):
+    """
+    Temporary endpoint to prove we can authenticate this request properly
+    """
+    user = request.user
+    exam = get_exam_by_id(exam_id)
+    if not user.is_staff and not user.has_course_staff_permission(exam.course_id):
+        return Response(status=status.HTTP_403_FORBIDDEN)
+
+    attempts = get_exam_attempts(exam_id)
+    attempts.select_related('user')
+
+    users = set(attempt.user for attempt in attempts)
+    roster = [
+        (user.anonymous_user_id, user.username)
+        for user in users
+    ]
+
+    return JsonResponse(roster, safe=False)

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -341,7 +341,6 @@ def end_assessment(request, attempt_id):
 @authentication_classes((JwtAuthentication,))
 @permission_classes((IsAuthenticated,))
 def launch_instructor_tool(request, exam_id):
-    # pragma: no cover
     """
     View to initiate an LTI launch of the Instructor Tool for an exam.
     """
@@ -381,6 +380,7 @@ def launch_instructor_tool(request, exam_id):
 @csrf_exempt
 @require_http_methods(['GET'])
 def exam_roster(request, exam_id):
+    # pragma: no cover
     """
     Temporary endpoint to prove we can authenticate this request properly
     """

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -118,6 +118,7 @@ SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_DOMAIN = 'localhost'
 
 ROOT_URL = 'http://localhost:18740'
+LTI_API_BASE = 'http://localhost:18740'
 LMS_ROOT_URL = 'http://localhost:18000'
 LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
 EXAMS_DASHBOARD_MFE_URL = 'http://localhost:2020'

--- a/edx_exams/settings/test.py
+++ b/edx_exams/settings/test.py
@@ -23,6 +23,7 @@ JWT_AUTH.update(
 )
 
 ROOT_URL = 'http://test.exams:18740'
+LTI_API_BASE = 'http://test.exams:18740'
 LMS_ROOT_URL = 'http://test.lms:18000'
 LEARNING_MICROFRONTEND_URL = 'http://test.learning:2000'
 


### PR DESCRIPTION
**JIRA:** [COSMO-52](https://2u-internal.atlassian.net/browse/COSMO-52?atlOrigin=eyJpIjoiY2VhNTVjZGQzOGFmNGVkYzhiNTVhMTBhYTY3ZThmYmYiLCJwIjoiaiJ9)

**Description:** This is an experimental feature to test out an approach for passing a course roster to the Proctorio app. Long term it would be ideal that this app and any future apps use existing LTI endpoints such as the Names and Roles Provisioning endpoint to access this data. This one-off url is ultimately a shortcut to get us to releasable state faster.

Basically we make use of the same auth pattern we created for the start proctoring launch where we mint a new session token to be used in a third party UI flow since the correct headers to use default JWT auth won't be set. See #59 
