### PR TITLE
fix: wrong user id sent to event bus

### DIFF
--- a/edx_exams/apps/core/signals/signals.py
+++ b/edx_exams/apps/core/signals/signals.py
@@ -17,7 +17,7 @@ def _create_user_data(user):
     Helper function to create a UserData object.
     """
     user_data = UserData(
-        id=user.id,
+        id=user.lms_user_id,
         is_active=user.is_active,
         pii=UserPersonalData(
             username=user.username,

--- a/edx_exams/apps/core/tests/test_api.py
+++ b/edx_exams/apps/core/tests/test_api.py
@@ -317,7 +317,7 @@ class TestUpdateAttemptStatus(ExamsAPITestCase):
             self.assertEqual(mock_event_send.call_count, 1)
 
             user_data = UserData(
-                id=self.user.id,
+                id=self.user.lms_user_id,
                 is_active=self.user.is_active,
                 pii=UserPersonalData(
                     username=self.user.username,
@@ -650,7 +650,7 @@ class TestResetExamAttempt(ExamsAPITestCase):
         reset_exam_attempt(self.exam_attempt, self.user)
 
         user_data = UserData(
-            id=self.student_user.id,
+            id=self.student_user.lms_user_id,
             is_active=self.student_user.is_active,
             pii=UserPersonalData(
                 username=self.student_user.username,
@@ -659,7 +659,7 @@ class TestResetExamAttempt(ExamsAPITestCase):
             )
         )
         requesting_user_data = UserData(
-            id=self.user.id,
+            id=self.user.lms_user_id,
             is_active=self.user.is_active,
             pii=UserPersonalData(
                 username=self.user.username,


### PR DESCRIPTION
**JIRA:** [COSMO-82](https://2u-internal.atlassian.net/browse/COSMO-82)

**Description:** This was sending the database id from edx-exams. We should always be using lms_user_id when sending an user id to other systems.

