### PR TITLE
feat: add custom domain param to LTI launch

### DIFF
--- a/edx_exams/apps/lti/tests/test_views.py
+++ b/edx_exams/apps/lti/tests/test_views.py
@@ -424,6 +424,9 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
             proctoring_launch_data=expected_proctoring_launch_data,
             context_id=self.course_id,
             context_label=self.content_id,
+            custom_parameters={
+                'custom_url': 'https://test.learning:2000/exam',
+            },
         )
 
         mock_get_lti_launch_url.assert_called_with(expected_launch_data)

--- a/edx_exams/apps/lti/views.py
+++ b/edx_exams/apps/lti/views.py
@@ -263,6 +263,10 @@ def start_proctoring(request, attempt_id):
         context_label=exam.content_id,
     )
 
+    # temporary addition for testing with Proctorio in stage
+    if settings.LTI_CUSTOM_URL_CLAIM:  # pragma: no cover
+        launch_data.custom_parameters['custom_url'] = settings.LTI_CUSTOM_URL_CLAIM
+
     return redirect(get_lti_1p3_launch_start_url(launch_data))
 
 

--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -280,6 +280,8 @@ LEARNING_MICROFRONTEND_URL = None
 
 EXAMS_DASHBOARD_MFE_URL = None
 
+LTI_CUSTOM_URL_CLAIM = None
+
 # Event Bus Settings
 EXAM_ATTEMPT_EVENTS_KAFKA_TOPIC_NAME = 'learning-exam-attempt-lifecycle'
 

--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -121,6 +121,7 @@ ROOT_URL = 'http://localhost:18740'
 LTI_API_BASE = 'http://localhost:18740'
 LMS_ROOT_URL = 'http://localhost:18000'
 LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
+LTI_CUSTOM_URL_CLAIM = 'http://localhost:2000'
 EXAMS_DASHBOARD_MFE_URL = 'http://localhost:2020'
 
 CORS_ORIGIN_WHITELIST = (

--- a/edx_exams/settings/test.py
+++ b/edx_exams/settings/test.py
@@ -26,6 +26,7 @@ ROOT_URL = 'http://test.exams:18740'
 LTI_API_BASE = 'http://test.exams:18740'
 LMS_ROOT_URL = 'http://test.lms:18000'
 LEARNING_MICROFRONTEND_URL = 'http://test.learning:2000'
+LTI_CUSTOM_URL_CLAIM = 'https://test.learning:2000/exam'
 
 TOKEN_SIGNING.update({
     'JWT_PRIVATE_SIGNING_JWK': '''{


### PR DESCRIPTION
**JIRA:** [COSMO-126](https://2u-internal.atlassian.net/browse/COSMO-126?atlOrigin=eyJpIjoiOTBiNTIyMGZkZDQ3NDVlNmJkYzY2M2MzNzU5NjFhZWEiLCJwIjoiaiJ9)

**Description:**

Adds a `custom_url` parameter to the LTI launch. We'll use this to test a few possible approaches to using this url. More details in [COSMO-105](https://2u-internal.atlassian.net/browse/COSMO-105)

I've added an entirely new setting for this since that gives us maximum flexibility to play around in stage but I expect the end solution will be a bit more elegant and just use the existing MFE url setting.