### PR TITLE
feat: add escalation email to ProctoringSettingsView

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1684,34 +1684,18 @@ class CourseExamAttemptViewTest(ExamsAPITestCase):
         self.assertIsNone(response_exam['backend'])
 
 
-class CourseProviderSettingsViewTest(ExamsAPITestCase):
+class ProctoringSettingsViewTest(ExamsAPITestCase):
     """
-    Tests CourseProviderSettings View
+    Tests ProctoringSettingsView
     """
 
     def setUp(self):
         super().setUp()
 
-        self.course_id = 'course-v1:edx+test+f19'
-        self.content_id = 'block-v1:edX+test+2023+type@sequential+block@1111111111'
+        self.config = CourseExamConfigurationFactory()
 
-        self.course_exam_config = CourseExamConfiguration.objects.create(
-            course_id=self.course_id,
-            provider=self.test_provider,
-            allow_opt_out=False
-        )
-
-        self.exam = Exam.objects.create(
-            resource_id=str(uuid.uuid4()),
-            course_id=self.course_id,
-            provider=self.test_provider,
-            content_id=self.content_id,
-            exam_name='test_exam',
-            exam_type='proctored',
-            time_limit_mins=30,
-            due_date='2040-07-01T00:00:00Z',
-            hide_after_due=False,
-            is_active=True
+        self.exam = ExamFactory(
+            provider=self.test_provider
         )
 
     def get_api(self, user, course_id, exam_id):
@@ -1721,7 +1705,7 @@ class CourseProviderSettingsViewTest(ExamsAPITestCase):
 
         headers = self.build_jwt_headers(user)
         url = reverse(
-            'api:v1:exam-provider-settings',
+            'api:v1:proctoring-settings',
             kwargs={'course_id': course_id, 'exam_id': exam_id}
         )
 
@@ -1731,15 +1715,15 @@ class CourseProviderSettingsViewTest(ExamsAPITestCase):
         """
         Test that the endpoint returns for an invalid exam ID
         """
-        response = self.get_api(self.user, self.course_id, 12345)
+        response = self.get_api(self.user, self.exam.course_id, 12345)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data, {})
+        self.assertEqual(response.data, {'proctoring_escalation_email': self.config.escalation_email})
 
     def test_exam_provider(self):
         """
         Test that the exam provider info is returned
         """
-        response = self.get_api(self.user, self.course_id, self.exam.id)
+        response = self.get_api(self.user, self.exam.course_id, self.exam.id)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data,
@@ -1747,5 +1731,6 @@ class CourseProviderSettingsViewTest(ExamsAPITestCase):
                 'provider_tech_support_email': self.test_provider.tech_support_email,
                 'provider_tech_support_phone': self.test_provider.tech_support_phone,
                 'provider_name': self.test_provider.verbose_name,
+                'proctoring_escalation_email': self.config.escalation_email,
             }
         )

--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -6,12 +6,12 @@ from edx_exams.apps.api.v1.views import (
     CourseExamAttemptView,
     CourseExamConfigurationsView,
     CourseExamsView,
-    CourseProviderSettingsView,
     ExamAccessTokensView,
     ExamAttemptView,
     InstructorAttemptsListView,
     LatestExamAttemptView,
-    ProctoringProvidersView
+    ProctoringProvidersView,
+    ProctoringSettingsView
 )
 from edx_exams.apps.core.constants import CONTENT_ID_PATTERN, COURSE_ID_PATTERN, EXAM_ID_PATTERN
 
@@ -65,7 +65,7 @@ urlpatterns = [
     ),
     re_path(
         fr'exam/provider_settings/course_id/{COURSE_ID_PATTERN}/exam_id/{EXAM_ID_PATTERN}',
-        CourseProviderSettingsView.as_view(),
-        name='exam-provider-settings'
+        ProctoringSettingsView.as_view(),
+        name='proctoring-settings'
     ),
 ]

--- a/edx_exams/apps/core/data.py
+++ b/edx_exams/apps/core/data.py
@@ -1,0 +1,12 @@
+"""
+Public data structures for the core applictaion.
+"""
+from attrs import field, frozen, validators
+
+
+@frozen
+class CourseExamConfigurationData:
+    course_id: str = field(validator=validators.instance_of(str))
+    provider: str = field(validator=validators.instance_of(str))
+    allow_opt_out: field(validator=validators.instance_of(str))
+    escalation_email: str = field(validator=validators.instance_of(str))

--- a/edx_exams/apps/router/middleware.py
+++ b/edx_exams/apps/router/middleware.py
@@ -6,20 +6,16 @@ import logging
 
 from django.utils.deprecation import MiddlewareMixin
 
-from edx_exams.apps.api.v1.views import CourseExamAttemptView, CourseExamsView, CourseProviderSettingsView
+from edx_exams.apps.api.v1.views import CourseExamAttemptView, CourseExamsView, ProctoringSettingsView
 from edx_exams.apps.core.models import CourseExamConfiguration
-from edx_exams.apps.router.views import (
-    CourseExamAttemptLegacyView,
-    CourseExamsLegacyView,
-    CourseProviderSettingsLegacyView
-)
+from edx_exams.apps.router.views import CourseExamAttemptLegacyView, CourseExamsLegacyView, ProctoringSettingsLegacyView
 
 log = logging.getLogger(__name__)
 
 LEGACY_VIEW_MAP = {
     CourseExamsView: CourseExamsLegacyView,
     CourseExamAttemptView: CourseExamAttemptLegacyView,
-    CourseProviderSettingsView: CourseProviderSettingsLegacyView,
+    ProctoringSettingsView: ProctoringSettingsLegacyView,
 }
 
 

--- a/edx_exams/apps/router/tests/test_views.py
+++ b/edx_exams/apps/router/tests/test_views.py
@@ -284,7 +284,7 @@ class CourseProviderSettingsLegacyViewTest(ExamsAPITestCase):
         self.course_id = 'course-v1:edx+test+f19'
         self.exam_id = 2222
         self.url = reverse(
-            'api:v1:exam-provider-settings',
+            'api:v1:proctoring-settings',
             kwargs={'course_id': self.course_id, 'exam_id': self.exam_id}
         )
 

--- a/edx_exams/apps/router/views.py
+++ b/edx_exams/apps/router/views.py
@@ -85,7 +85,7 @@ class CourseExamAttemptLegacyView(APIView):
         )
 
 
-class CourseProviderSettingsLegacyView(APIView):
+class ProctoringSettingsLegacyView(APIView):
     """
     View to handle provider settings for exams managed by edx-proctoring
     """

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,7 @@
 # Core requirements for using this application
 -c constraints.txt
 
+attrs
 Django         # Web application framework
 django-cors-headers
 django-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,7 @@ async-timeout==4.0.3
     # via redis
 attrs==23.1.0
     # via
+    #   -r requirements/base.in
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.1.0

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,4 +1,5 @@
 
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -106,7 +106,6 @@ cryptography==41.0.7
     # via
     #   -r requirements/validation.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.7.0
     # via -r requirements/validation.txt
@@ -335,11 +334,6 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/validation.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/validation.txt
@@ -626,10 +620,6 @@ s3transfer==0.8.0
     # via
     #   -r requirements/validation.txt
     #   boto3
-secretstorage==3.3.3
-    # via
-    #   -r requirements/validation.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/validation.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -105,7 +105,6 @@ cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.7.0
     # via -r requirements/test.txt
@@ -330,10 +329,6 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -590,8 +585,6 @@ s3transfer==0.8.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -99,7 +99,6 @@ cryptography==41.0.7
     # via
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.7.0
     # via -r requirements/test.txt
@@ -315,10 +314,6 @@ itypes==1.2.0
     #   coreapi
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -568,8 +563,6 @@ s3transfer==0.8.0
     # via
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -120,7 +120,6 @@ cryptography==41.0.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
-    #   secretstorage
     #   social-auth-core
 ddt==1.7.0
     # via
@@ -404,11 +403,6 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/quality.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/quality.txt
@@ -732,10 +726,6 @@ s3transfer==0.8.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   boto3
-secretstorage==3.3.3
-    # via
-    #   -r requirements/quality.txt
-    #   keyring
 semantic-version==2.10.0
     # via
     #   -r requirements/quality.txt


### PR DESCRIPTION
**JIRA:** [COSMO-39](https://2u-internal.atlassian.net/browse/COSMO-39)

**Description:** This commit renames the `CourseProviderSettingsView` view to `ProctoringSettingsView` to accommodate additional settings beyond just provider settings; this more closely mirrors the purpose of the analogous `edx-proctoring` view. This commit also adds the escalation email to the response under the `proctoring_escalation_email` key. This changes allows the escalation email to appear in the error interstitial in the learning MFE.

**Screenshots:**

_Before:_

<img width="1628" alt="Screenshot 2023-12-12 at 2 27 27 PM" src="https://github.com/edx/edx-exams/assets/11871801/7ad06fcd-6bd5-447d-9a89-de87f1a5c76f">

_After:_

<img width="1641" alt="Screenshot 2023-12-12 at 2 26 50 PM" src="https://github.com/edx/edx-exams/assets/11871801/df0c3a33-cc06-434a-b1bf-25b7137d6898">

**Author concerns:** None.

**Dependencies:** None.

**Installation instructions:** None.

**Testing instructions:**

1. Set the `escalation_email` field on the `CourseExamConfiguration` model instance associated with the course in which you will take an exam.
2. Start a proctored exam.
3. Move the associated attempt into the `error` state.
4. Verify that the new escalation email appears in the template and that clicking it opens an email client.

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
