### PR TITLE
fix: not all usage keys matching

### DIFF
--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -13,7 +13,7 @@ from edx_exams.apps.api.v1.views import (
     ProctoringProvidersView,
     ProctoringSettingsView
 )
-from edx_exams.apps.core.constants import CONTENT_ID_PATTERN, COURSE_ID_PATTERN, EXAM_ID_PATTERN
+from edx_exams.apps.core.constants import COURSE_ID_PATTERN, EXAM_ID_PATTERN, USAGE_KEY_PATTERN
 
 app_name = 'v1'
 
@@ -59,7 +59,7 @@ urlpatterns = [
         name='instructor-attempts-list'
     ),
     re_path(
-        fr'student/exam/attempt/course_id/{COURSE_ID_PATTERN}/content_id/{CONTENT_ID_PATTERN}',
+        fr'student/exam/attempt/course_id/{COURSE_ID_PATTERN}/content_id/{USAGE_KEY_PATTERN}',
         CourseExamAttemptView.as_view(),
         name='student-course_exam_attempt'
     ),

--- a/edx_exams/apps/core/constants.py
+++ b/edx_exams/apps/core/constants.py
@@ -15,6 +15,6 @@ EXTERNAL_COURSE_KEY_PATTERN = r'([A-Za-z0-9-_:]+)'
 
 COURSE_ID_PATTERN = rf'(?P<course_id>({INTERNAL_COURSE_KEY_PATTERN}|{EXTERNAL_COURSE_KEY_PATTERN}))'
 
-CONTENT_ID_PATTERN = r'(?P<content_id>([A-Za-z0-9-_:@\+]+))'
+USAGE_KEY_PATTERN = r'(?P<content_id>(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+))'
 
 EXAM_ID_PATTERN = r'(?P<exam_id>\d+)'


### PR DESCRIPTION
Fixes a bug where the existing regex would not match the entire content id into the capture group

This would break exams for any course with a `.` in the course id (and likely several other cases).