### PR TITLE
feat: add proctorio redirect url

### DIFF
--- a/edx_exams/apps/core/admin.py
+++ b/edx_exams/apps/core/admin.py
@@ -3,8 +3,7 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.utils.translation import gettext_lazy as _
-
-from edx_exams.apps.lti.utils import get_lti_root
+from lti_consumer.utils import get_lti_api_base
 
 from .models import (
     AssessmentControlResult,
@@ -61,7 +60,10 @@ class ExamAttemptAdmin(admin.ModelAdmin):
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
         extra_context = extra_context or {}
-        extra_context['LTI_ROOT'] = get_lti_root()
+        # technically this should be be using get_lti_view_base() but the
+        # setting behind that isn't available in edx-exams and we know they
+        # are the same in this service.
+        extra_context['LTI_ROOT'] = get_lti_api_base()
         return super().change_view(
             request, object_id, form_url, extra_context=extra_context,
         )

--- a/edx_exams/apps/lti/tests/test_views.py
+++ b/edx_exams/apps/lti/tests/test_views.py
@@ -14,6 +14,7 @@ from django.urls import reverse
 from lti_consumer.data import Lti1p3LaunchData, Lti1p3ProctoringLaunchData
 from lti_consumer.lti_1p3.extensions.rest_framework.authentication import Lti1p3ApiAuthentication
 from lti_consumer.models import LtiConfiguration, LtiProctoringConsumer
+from lti_consumer.utils import get_lti_api_base
 
 from edx_exams.apps.api.test_utils import ExamsAPITestCase, UserFactory
 from edx_exams.apps.core.models import AssessmentControlResult, CourseStaffRole
@@ -24,7 +25,6 @@ from edx_exams.apps.core.test_utils.factories import (
     ExamFactory,
     ProctoringProviderFactory
 )
-from edx_exams.apps.lti.utils import get_lti_root
 
 log = logging.getLogger(__name__)
 
@@ -404,7 +404,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
         self.client.get(self.url, **headers)
 
         expected_proctoring_start_assessment_url = urljoin(
-            get_lti_root(),
+            get_lti_api_base(),
             reverse('lti_consumer:lti_consumer.start_proctoring_assessment_endpoint')
         )
         expected_proctoring_launch_data = Lti1p3ProctoringLaunchData(
@@ -425,7 +425,7 @@ class LtiStartProctoringTestCase(ExamsAPITestCase):
             context_id=self.course_id,
             context_label=self.content_id,
             custom_parameters={
-                'custom_url': 'https://test.learning:2000/exam',
+                'custom_url': 'test.exams:18740/browser_lock/',
             },
         )
 

--- a/edx_exams/apps/lti/utils.py
+++ b/edx_exams/apps/lti/utils.py
@@ -1,8 +1,0 @@
-"""
-LTI Utility Functions
-"""
-from django.conf import settings
-
-
-def get_lti_root():
-    return settings.ROOT_URL

--- a/edx_exams/urls.py
+++ b/edx_exams/urls.py
@@ -21,6 +21,7 @@ from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import RedirectView
 from edx_api_doc_tools import make_api_info, make_docs_urls
 
 from edx_exams.apps.api import urls as api_urls
@@ -37,6 +38,9 @@ urlpatterns = oauth2_urlpatterns + [
     path('health/', core_views.Health.as_view(), name='health'),
     path('lti/', include(lti_urls)),
     path('lti/', include('lti_consumer.plugin.urls')),
+    # url for the exam inside the Proctorio browser extension the browser will fall through
+    # to this redirect if the browser extension is not installed
+    path('browser_lock/', RedirectView.as_view(url='https://getproctorio.com'), name='browser_lock'),
 ]
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover


### PR DESCRIPTION
**JIRA:** [COSMO-105](https://2u-internal.atlassian.net/browse/COSMO-105)

**Description:**

`custom_url` represents the url seen in the browser during an exam. When the extension is installed navigating to this URL will activate it and iframe in the exam content. By using a url we own we can handle what happens when the extension is not installed since the GET to /browser_lock will hit this service. If that happens we redirect the learner to getproctorio.com to install the extension.

The downside of this approach is getproctorio.com can't send the user back into the exam since we don't own that page. The learner would need to manually navigate back the the section and click start system check again.

To make this flow a bit smoother we would prefer learners download the extension first, before ever clicking 'start system check'. This ticket [COSMO-130](https://2u-internal.atlassian.net/browse/COSMO-130?atlOrigin=eyJpIjoiOTllMTliMDUxZTkzNDZmZTliYjlkMTE3YzkzMjYxYWYiLCJwIjoiaiJ9) adds that instruction to the interstitial. If they miss or ignore that instruction this PR will redirect them on the download page either way.

Note: We enforce the domain of messages from the extension. That will need to update along with this https://github.com/openedx/frontend-lib-special-exams/pull/126