### PR TITLE
feat: add full html page for proctorio launch

### DIFF
--- a/edx_exams/templates/proctorio_download.html
+++ b/edx_exams/templates/proctorio_download.html
@@ -1,1 +1,31 @@
-loading Proctorio extension...
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+            background-color: #f4f4f4;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+
+        .container {
+            text-align: center;
+            max-width: 600px;
+            padding: 20px;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Launching Proctorio application...</h1>
+        <p>If your exam does not start in the next 5 seconds visit <a href="https://getproctorio.com" target="_blank">getproctorio.com</a> to download the latest browser extension.</p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Confimed with Proctorio devs that so long as we return a valid HTML document this page will be hidden by the extension.

This is what the user would see briefly before the extension starts or if they do not have it installed:

<img width="1160" alt="Screenshot 2023-12-18 at 1 22 06 PM" src="https://github.com/edx/edx-exams/assets/5661461/76bb5bd4-526e-48ac-bf72-48384dc1927b">
