### PR TITLE
fix: performance issue with coursestaffrole admin

### DIFF
--- a/edx_exams/apps/core/admin.py
+++ b/edx_exams/apps/core/admin.py
@@ -98,6 +98,7 @@ class AssessmentControlResultAdmin(admin.ModelAdmin):
 @admin.register(CourseStaffRole)
 class CourseStaffRoleAdmin(admin.ModelAdmin):
     """ Admin configuration for the Course Staff Role model """
+    raw_id_fields = ('user',)
     list_display = ('user', 'course_id')
     list_filter = ('course_id',)
     search_fields = ('user__username', 'course_id')


### PR DESCRIPTION
The default behavior of this field would be to put every row in the user table into the dropdown. That table is too big to render in a template, and worse, this could potentially lock up the database querying for every record.