### PR TITLE
feat: upgrade event bus kafka to allow for setting client ids when publishing/consuming events

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -144,7 +144,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/base.in
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/base.in
 edx-event-bus-redis==0.3.2
     # via -r requirements/base.in
@@ -220,7 +220,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 openedx-django-pyfs==3.4.1
     # via lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/base.in
     #   edx-event-bus-kafka

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -239,7 +239,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/validation.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/validation.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/validation.txt
@@ -418,7 +418,7 @@ openedx-django-pyfs==3.4.1
     # via
     #   -r requirements/validation.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/validation.txt
     #   edx-event-bus-kafka

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -237,7 +237,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/test.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/test.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/test.txt
@@ -402,7 +402,7 @@ openedx-django-pyfs==3.4.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -185,7 +185,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/base.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/base.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/base.txt
@@ -300,7 +300,7 @@ openedx-django-pyfs==3.4.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -225,7 +225,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/test.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/test.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/test.txt
@@ -386,7 +386,7 @@ openedx-django-pyfs==3.4.1
     # via
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -209,7 +209,7 @@ edx-django-utils==5.10.1
     #   edx-toggles
 edx-drf-extensions==9.1.2
     # via -r requirements/base.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via -r requirements/base.txt
 edx-event-bus-redis==0.3.2
     # via -r requirements/base.txt
@@ -338,7 +338,7 @@ openedx-django-pyfs==3.4.1
     # via
     #   -r requirements/base.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -284,7 +284,7 @@ edx-drf-extensions==9.1.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-edx-event-bus-kafka==5.5.0
+edx-event-bus-kafka==5.6.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -503,7 +503,7 @@ openedx-django-pyfs==3.4.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==9.2.0
+openedx-events==9.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
Will set the client.id to EVENTS_SERVICE_NAME (to be added in a separate PR)