### PR TITLE
fix: replace username with full name in attemp emails

### DIFF
--- a/edx_exams/apps/core/email.py
+++ b/edx_exams/apps/core/email.py
@@ -26,10 +26,13 @@ def send_attempt_status_email(attempt, escalation_email=None):
 
     if attempt.status == ExamAttemptStatus.submitted:
         email_template = 'email/proctoring_attempt_submitted.html'
+        email_subject = 'Proctoring attempt submitted'
     elif attempt.status == ExamAttemptStatus.verified:
         email_template = 'email/proctoring_attempt_verified.html'
+        email_subject = 'Proctoring attempt verified'
     elif attempt.status == ExamAttemptStatus.rejected:
         email_template = 'email/proctoring_attempt_rejected.html'
+        email_subject = 'Proctoring attempt rejected'
     else:
         return  # do not send emails for other statuses
 
@@ -44,7 +47,6 @@ def send_attempt_status_email(attempt, escalation_email=None):
         contact_url = f'{settings.LMS_ROOT_URL}/support/contact_us'
         contact_url_text = contact_url
 
-    email_subject = f'Proctored exam {exam.exam_name} for user {attempt.user.username}'
     body = email_template.render({
         'exam_name': exam.exam_name,
         'course_url': course_url,

--- a/edx_exams/apps/core/templates/email/proctoring_attempt_rejected.html
+++ b/edx_exams/apps/core/templates/email/proctoring_attempt_rejected.html
@@ -3,7 +3,7 @@
 <p>
     {% block introduction %}
     {% blocktrans %}
-        Hello {{ username }},
+        Hello,
     {% endblocktrans %}
     {% endblock %}
 </p>

--- a/edx_exams/apps/core/templates/email/proctoring_attempt_submitted.html
+++ b/edx_exams/apps/core/templates/email/proctoring_attempt_submitted.html
@@ -3,7 +3,7 @@
 <p>
     {% block introduction %}
     {% blocktrans %}
-        Hello {{ username }},
+        Hello,
     {% endblocktrans %}
     {% endblock %}
 </p>

--- a/edx_exams/apps/core/templates/email/proctoring_attempt_verified.html
+++ b/edx_exams/apps/core/templates/email/proctoring_attempt_verified.html
@@ -3,7 +3,7 @@
 <p>
     {% block introduction %}
     {% blocktrans %}
-        Hello {{ username }},
+        Hello,
     {% endblocktrans %}
     {% endblock %}
 </p>


### PR DESCRIPTION
**JIRA:** 
[VAN-1833](https://2u-internal.atlassian.net/browse/VAN-1833)

**Description:** 
Remove username and change subject in attempts emails 

**Testing instructions:**
It has been tested locally 

| Before  | After |
| ------------- | ------------- |
|  ![image](https://github.com/edx/edx-exams/assets/12580995/7452cae4-9310-457c-bd91-3c767a3f9e7c) | ![image](https://github.com/edx/edx-exams/assets/12580995/020e69c6-5cb1-47bb-bc3f-a093e3fff6dc)  |
|  ![image](https://github.com/edx/edx-exams/assets/12580995/2d7ae244-41c6-476c-9d54-9c9c37752d60) | ![image](https://github.com/edx/edx-exams/assets/12580995/222e69ad-39d4-473d-adfd-e627306ebeb0)|


