### PR TITLE
fix: dont run model unique constraint on ExamSerializer

### DIFF
--- a/edx_exams/apps/api/serializers.py
+++ b/edx_exams/apps/api/serializers.py
@@ -133,6 +133,9 @@ class ExamSerializer(serializers.ModelSerializer):
             'id', 'exam_name', 'course_id', 'content_id', 'time_limit_mins', 'due_date', 'exam_type',
             'hide_after_due', 'is_active'
         )
+        # since we use this to bulk create or update without a pk we cannot run the unique constraint
+        # validator on the model since it won't know which operation we are doing at validation time.
+        validators = []
 
     def validate_exam_type(self, value):
         """


### PR DESCRIPTION
This serializer will fail to validate any 'update' operation once DRF 3.15 is pulled in. This endpoint is designed to validate the payload first than update or create objects as needed. The problem with this is the validator won't know we're updating an existing instance or creating a new one so it rejects any update to an existing exam row. This constraint isn't valuable on this endpoint anyway since if it already exists we're always going to update, it's impossible to create duplicates.

This was only working before due to https://github.com/encode/django-rest-framework/issues/7173 which got fixed in 3.15.