### PR TITLE
fix: handle dupe user case for mgmt cmd

### DIFF
--- a/edx_exams/apps/core/management/commands/bulk_add_course_staff.py
+++ b/edx_exams/apps/core/management/commands/bulk_add_course_staff.py
@@ -68,6 +68,7 @@ class Command(BaseCommand):
         for row in reader:
             if row.get('username') not in users_existing:
                 users_to_create.append(row)
+                users_existing.add(row.get('username'))
 
         # bulk create users
         for i in range(0, len(users_to_create), batch_size):

--- a/edx_exams/apps/core/management/commands/test/test_bulk_add_course_staff.py
+++ b/edx_exams/apps/core/management/commands/test/test_bulk_add_course_staff.py
@@ -117,3 +117,16 @@ class TestBulkAddCourseStaff(TestCase):
             csv = self._write_test_csv(csv, lines)
             with self.assertNumQueries(5 + num_lines):
                 call_command(self.command, f'--csv_path={csv.name}')
+
+    def test_dupe_user_csv(self):
+        """ Assert that the course staff roles are correctly created given duplicate users in csv """
+        username, email = 'pam', 'pam@pond.com'
+        course_id_2 = 'course-v1:edx+test+f21'
+        lines = [f'{username},{email},{self.course_role},{self.course_id}\n',
+                 f'{username},{email},{self.course_role},{course_id_2}\n']
+
+        with NamedTemporaryFile() as csv:
+            csv = self._write_test_csv(csv, lines)
+            call_command(self.command, f'--csv_path={csv.name}')
+            self._assert_user_and_role(username, email, self.course_role, self.course_id)
+            self._assert_user_and_role(username, email, self.course_role, course_id_2)


### PR DESCRIPTION
**JIRA:** [Link to JIRA ticket](https://2u-internal.atlassian.net/browse/COSMO-236)

**Description:** When SRE tried to run the mgmt command in stage, there was an IntegrityError. After investigating, I realized there was a bug/missing edge case. This fix handles the case where there is a duplicate user in the csv itself (previously, was only checking if there was an existing User in the db)

**Author concerns:** Is this a case I should handle for duplicate CourseStaffRole entries in the CSV? I'm guessing no, because there shouldn't be duplicate entries when pulling from the db.