### PR TITLE
feat: GET allowances

### DIFF
--- a/edx_exams/apps/api/serializers.py
+++ b/edx_exams/apps/api/serializers.py
@@ -280,3 +280,29 @@ class InstructorViewAttemptSerializer(serializers.ModelSerializer):
             'allowed_time_limit_mins', 'exam_type', 'exam_display_name', 'username',
             'proctored_review',
         )
+
+
+class AllowanceSerializer(serializers.ModelSerializer):
+    """
+    Serializer for the Allowance model
+    """
+
+    # directly from the Allowance Model
+    id = serializers.IntegerField(required=False)
+    exam_id = serializers.IntegerField()
+    user_id = serializers.IntegerField()
+    extra_time_mins = serializers.IntegerField()
+
+    # custom fields based on related models
+    username = serializers.CharField(source='user.username')
+    exam_name = serializers.CharField(source='exam.exam_name')
+
+    class Meta:
+        """
+        Meta Class
+        """
+        model = ExamAttempt
+
+        fields = (
+            'id', 'exam_id', 'user_id', 'extra_time_mins', 'username', 'exam_name'
+        )

--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1800,7 +1800,7 @@ class AllowanceViewTests(ExamsAPITestCase):
         # course staff has access
         course_staff_user = UserFactory.create()
         CourseStaffRole.objects.create(user=course_staff_user, course_id=self.course_id)
-        response = self.get_api(course_staff_user, self.course_id)
+        response = self.request_api('get', course_staff_user, self.course_id)
         self.assertEqual(response.status_code, 200)
 
     def test_get_allowances(self):
@@ -1808,12 +1808,7 @@ class AllowanceViewTests(ExamsAPITestCase):
         Test that the endpoint returns allowances for the requested course
         and only the requested course
         """
-        other_exam_in_course = ExamFactory.create(
-            course_id=self.exam.course_id,
-        )
-        another_course_exam = ExamFactory.create(
-            course_id='course-v1:edx+another+course',
-        )
+        other_exam_in_course = ExamFactory.create(course_id=self.exam.course_id)
         StudentAllowanceFactory.create(
             exam=self.exam,
             user=self.user,
@@ -1823,7 +1818,7 @@ class AllowanceViewTests(ExamsAPITestCase):
             user=self.user,
         )
         StudentAllowanceFactory.create(
-            exam=another_course_exam,
+            exam=ExamFactory.create(course_id='course-v1:edx+another+course'),
             user=self.user,
         )
 
@@ -1848,3 +1843,11 @@ class AllowanceViewTests(ExamsAPITestCase):
             'username': self.user.username,
             'extra_time_mins': 30,
         })
+
+    def test_get_empty_response(self):
+        """
+        Test that the endpoint returns an empty list if no allowances exist
+        """
+        response = self.request_api('get', self.user, 'course-v1:edx+no+allowances')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, [])

--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -25,6 +25,7 @@ from edx_exams.apps.core.test_utils.factories import (
     ExamAttemptFactory,
     ExamFactory,
     ProctoringProviderFactory,
+    StudentAllowanceFactory,
     UserFactory
 )
 
@@ -1752,3 +1753,98 @@ class ProctoringSettingsViewTest(ExamsAPITestCase):
                 'proctoring_escalation_email': self.config.escalation_email,
             }
         )
+
+
+class AllowanceViewTests(ExamsAPITestCase):
+    """
+    Tests AllowanceView
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.course_id = 'course-v1:edx+test+f19'
+        self.exam = ExamFactory(
+            course_id=self.course_id,
+        )
+
+    def request_api(self, method, user, course_id):
+        """
+        Helper function to make API request
+        """
+        assert method in ['get']
+        headers = self.build_jwt_headers(user)
+        url = reverse(
+            'api:v1:course-allowances',
+            kwargs={'course_id': course_id}
+        )
+
+        return getattr(self.client, method)(url, **headers)
+
+    def test_auth_required(self):
+        """
+        Test endpoint requires authentication and a staff user
+        """
+
+        # no auth
+        response = self.client.get(
+            reverse('api:v1:course-allowances', kwargs={'course_id': self.course_id}),
+        )
+        self.assertEqual(response.status_code, 401)
+
+        # no permissions
+        user = UserFactory.create(is_staff=False)
+        response = self.request_api('get', user, self.course_id)
+        self.assertEqual(response.status_code, 403)
+
+        # course staff has access
+        course_staff_user = UserFactory.create()
+        CourseStaffRole.objects.create(user=course_staff_user, course_id=self.course_id)
+        response = self.get_api(course_staff_user, self.course_id)
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_allowances(self):
+        """
+        Test that the endpoint returns allowances for the requested course
+        and only the requested course
+        """
+        other_exam_in_course = ExamFactory.create(
+            course_id=self.exam.course_id,
+        )
+        another_course_exam = ExamFactory.create(
+            course_id='course-v1:edx+another+course',
+        )
+        StudentAllowanceFactory.create(
+            exam=self.exam,
+            user=self.user,
+        )
+        StudentAllowanceFactory.create(
+            exam=other_exam_in_course,
+            user=self.user,
+        )
+        StudentAllowanceFactory.create(
+            exam=another_course_exam,
+            user=self.user,
+        )
+
+        response = self.request_api('get', self.user, self.exam.course_id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data), 2)
+
+        response.data.sort(key=lambda x: x['id'])
+        self.assertDictEqual(response.data[0], {
+            'id': 1,
+            'exam_id': self.exam.id,
+            'user_id': self.user.id,
+            'exam_name': self.exam.exam_name,
+            'username': self.user.username,
+            'extra_time_mins': 30,
+        })
+        self.assertDictEqual(response.data[1], {
+            'id': 2,
+            'exam_id': other_exam_in_course.id,
+            'user_id': self.user.id,
+            'exam_name': other_exam_in_course.exam_name,
+            'username': self.user.username,
+            'extra_time_mins': 30,
+        })

--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -3,6 +3,7 @@
 from django.urls import path, re_path
 
 from edx_exams.apps.api.v1.views import (
+    AllowanceView,
     CourseExamAttemptView,
     CourseExamConfigurationsView,
     CourseExamsView,
@@ -18,6 +19,11 @@ from edx_exams.apps.core.constants import COURSE_ID_PATTERN, EXAM_ID_PATTERN, US
 app_name = 'v1'
 
 urlpatterns = [
+    re_path(
+        fr'exams/course_id/{COURSE_ID_PATTERN}/allowances',
+        AllowanceView.as_view(),
+        name='course-allowances'
+    ),
     re_path(
         fr'exams/course_id/{COURSE_ID_PATTERN}',
         CourseExamsView.as_view(),

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -18,6 +18,7 @@ from token_utils.api import sign_token_for
 
 from edx_exams.apps.api.permissions import CourseStaffOrReadOnlyPermissions, CourseStaffUserPermissions
 from edx_exams.apps.api.serializers import (
+    AllowanceSerializer,
     CourseExamConfigurationReadSerializer,
     CourseExamConfigurationWriteSerializer,
     ExamSerializer,
@@ -45,7 +46,7 @@ from edx_exams.apps.core.api import (
     update_attempt_status
 )
 from edx_exams.apps.core.exam_types import get_exam_type
-from edx_exams.apps.core.models import CourseExamConfiguration, Exam, ExamAttempt, ProctoringProvider
+from edx_exams.apps.core.models import CourseExamConfiguration, Exam, ExamAttempt, ProctoringProvider, StudentAllowance
 from edx_exams.apps.core.statuses import ExamAttemptStatus
 from edx_exams.apps.router.interop import get_active_exam_attempt
 
@@ -779,3 +780,25 @@ class ProctoringSettingsView(ExamsAPIView):
         data['proctoring_escalation_email'] = config_data.escalation_email
 
         return Response(data)
+
+
+class AllowanceView(ExamsAPIView):
+    """
+    Endpoint for getting allowances in a course
+
+    /exams/course_id/{course_id}/allowances
+
+    Supports:
+        HTTP GET:
+            Returns a list of allowances for a course.
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (CourseStaffUserPermissions,)
+
+    def get(self, request, course_id):
+        """
+        HTTP GET handler. Returns a list of allowances for a course.
+        """
+        allowances = StudentAllowance.get_allowances_for_course(course_id)
+        return Response(AllowanceSerializer(allowances, many=True).data)

--- a/edx_exams/apps/core/admin.py
+++ b/edx_exams/apps/core/admin.py
@@ -109,6 +109,7 @@ class CourseStaffRoleAdmin(admin.ModelAdmin):
 @admin.register(StudentAllowance)
 class StudentAllowanceAdmin(admin.ModelAdmin):
     """ Admin configuration for the Student Allowance model """
+    raw_id_fields = ('user', 'exam')
     list_display = ('username', 'course_id', 'exam_name', 'extra_time_mins')
     search_fields = ('user__username', 'exam__course_id', 'exam__exam_name')
     ordering = ('-modified',)

--- a/edx_exams/apps/core/models.py
+++ b/edx_exams/apps/core/models.py
@@ -5,6 +5,7 @@ import uuid
 from django.contrib.auth.models import AbstractUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
@@ -447,3 +448,11 @@ class StudentAllowance(TimeStampedModel):
         db_table = 'exams_studentallowance'
         verbose_name = 'student allowance'
         unique_together = ('user', 'exam')
+
+    @classmethod
+    def get_allowances_for_course(cls, course_id):
+        """
+        Returns all the allowances for a course.
+        """
+        filtered_query = Q(exam__course_id=course_id)
+        return cls.objects.filter(filtered_query)

--- a/edx_exams/apps/core/test_utils/factories.py
+++ b/edx_exams/apps/core/test_utils/factories.py
@@ -14,7 +14,8 @@ from edx_exams.apps.core.models import (
     CourseStaffRole,
     Exam,
     ExamAttempt,
-    ProctoringProvider
+    ProctoringProvider,
+    StudentAllowance,
 )
 from edx_exams.apps.core.statuses import ExamAttemptStatus
 
@@ -129,3 +130,15 @@ class CourseStaffRoleFactory(DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
     course_id = 'course-v1:edX+Test+Test_Course'
     role = 'staff'
+
+
+class StudentAllowanceFactory(DjangoModelFactory):
+    """
+    Factory to create allowances
+    """
+    class Meta:
+        model = StudentAllowance
+
+    user = factory.SubFactory(UserFactory)
+    exam = factory.SubFactory(ExamFactory)
+    extra_time_mins = 30

--- a/edx_exams/apps/core/test_utils/factories.py
+++ b/edx_exams/apps/core/test_utils/factories.py
@@ -15,7 +15,7 @@ from edx_exams.apps.core.models import (
     Exam,
     ExamAttempt,
     ProctoringProvider,
-    StudentAllowance,
+    StudentAllowance
 )
 from edx_exams.apps.core.statuses import ExamAttemptStatus
 


### PR DESCRIPTION
**JIRA:** [COSMO-368](https://2u-internal.atlassian.net/browse/COSMO-368)

**Description:** Adds API to retrieve a list of allowances by course id

The story suggested using generic DRF views for this since there's no business logic. I tried that out but found would introduce a new pattern without making it much simpler really. It would also mess with our class for exception logging