### PR TITLE
fix: handle dupe course staff mgmt command

### DIFF
--- a/edx_exams/apps/core/management/commands/bulk_add_course_staff.py
+++ b/edx_exams/apps/core/management/commands/bulk_add_course_staff.py
@@ -63,32 +63,34 @@ class Command(BaseCommand):
         Add the given set of course staff provided in csv
         """
         reader = list(csv.DictReader(csv_file))
-        users_to_create = []
-        users_existing = {u.username for u in User.objects.filter(username__in=[r.get('username') for r in reader])}
-        for row in reader:
-            if row.get('username') not in users_existing:
-                users_to_create.append(row)
-                users_existing.add(row.get('username'))
 
         # bulk create users
-        for i in range(0, len(users_to_create), batch_size):
+        for i in range(0, len(reader), batch_size):
             User.objects.bulk_create(
-                User(
-                    username=user.get('username'),
-                    email=user.get('email'),
-                )
-                for user in users_to_create[i:i + batch_size]
+                (User(
+                    username=row.get('username'),
+                    email=row.get('email'),
+                ) for row in reader[i:i + batch_size]),
+                ignore_conflicts=True,
+            )
+            CourseStaffRole.objects.bulk_create(
+                (CourseStaffRole(
+                    user=User.objects.get(username=row.get('username')),
+                    course_id=row.get('course_id'),
+                    role=row.get('role'),
+                ) for row in reader[i:i + batch_size]),
+                ignore_conflicts=True,
             )
             time.sleep(batch_delay)
 
         # bulk create course staff
-        for i in range(0, len(reader), batch_size):
-            CourseStaffRole.objects.bulk_create(
-                CourseStaffRole(
-                    user=User.objects.get(username=row.get('username')),
-                    course_id=row.get('course_id'),
-                    role=row.get('role'),
-                )
-                for row in reader[i:i + batch_size]
-            )
-            time.sleep(batch_delay)
+        # for i in range(0, len(reader), batch_size):
+        #     CourseStaffRole.objects.bulk_create(
+        #         (CourseStaffRole(
+        #             user=User.objects.get(username=row.get('username')),
+        #             course_id=row.get('course_id'),
+        #             role=row.get('role'),
+        #         ) for row in reader[i:i + batch_size]),
+        #         ignore_conflicts=True,
+        #     )
+        #     time.sleep(batch_delay)


### PR DESCRIPTION
**JIRA:** [COSMO-234](https://2u-internal.atlassian.net/browse/COSMO-234)

**Description:** This PR updates the course staff role management command to use ignore_conflicts to handle duplicate/already existing users and course staff roles. This is more efficient, and more readable. I did do some research, test locally and find other usages to confirm that ignore_conflicts is supported in our environment.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
