### PR TITLE
feat: DEPR USE-JWT-COOKIE header

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -86,9 +86,7 @@ REST_FRAMEWORK = {
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers + (
-    'use-jwt-cookie',
-)
+CORS_ALLOW_HEADERS = corsheaders_default_headers
 CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = 'edx_exams.urls'


### PR DESCRIPTION
his repo is no longer using USE-JWT-COOKIE header, since it has the required edx-drf-extensions>10.2.0, where it was fully removed.

This is final clean-up for this repo.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

**JIRA:** Link to JIRA ticket

**Description:** Describe in a couple of sentences what this PR adds

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
