### PR TITLE
Revert "feat: DEPR USE-JWT-COOKIE header"

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -86,7 +86,9 @@ REST_FRAMEWORK = {
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers
+CORS_ALLOW_HEADERS = corsheaders_default_headers + (
+    'use-jwt-cookie',
+)
 CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = 'edx_exams.urls'


### PR DESCRIPTION
Reverts edx/edx-exams#312

A similar PR may have broken edx-platform, so reverting until investigation has completed. See https://github.com/openedx/edx-platform/pull/35397