### PR TITLE
fix: allow course staff role to be updated with email change

### DIFF
--- a/edx_exams/apps/core/signals/handlers.py
+++ b/edx_exams/apps/core/signals/handlers.py
@@ -23,10 +23,7 @@ def listen_for_course_access_role_added(sender, signal, **kwargs):  # pylint: di
     if role not in COURSE_STAFF_ROLES:
         return
 
-    user, _ = User.objects.get_or_create(
-        username=user_data.pii.username,
-        email=user_data.pii.email,
-    )
+    user, _ = User.objects.get_or_create(username=user_data.pii.username)
     CourseStaffRole.objects.get_or_create(
         user=user,
         course_id=course_key,


### PR DESCRIPTION
**JIRA:** [COSMO-478](https://2u-internal.atlassian.net/browse/COSMO-478)

**Description:** 
If a user is added to a course with either staff or instructor permissions, changes their email, and then is added to another course as staff or instructor, the second event meant to sync staff role permissions with edx-exams will fail due to an integrity/unique constraint error. This is because the call to get or create a new `User` object in the event handler is keyed off of both the `username` and `email` fields, which means that subsequent email changes will result in calls to create a new `User` object with the same `username` but new `email`, as opposed to just getting the existing `User` object. 

This bug is fixed by only using the `username` field to get or create a new `User` object. 

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
