### PR TITLE
Remove CSRF_TRUSTED_ORIGINS_WITH_SCHEMES variable

### DIFF
--- a/edx_exams/settings/production.py
+++ b/edx_exams/settings/production.py
@@ -57,6 +57,3 @@ for override, value in DB_OVERRIDES.items():
 
 # EMAIL CONFIGURATION
 EMAIL_BACKEND = 'django_ses.SESBackend'
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
## Description

- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/460
- Since we have upgraded to Django 4.2, we can remove the additional condition and variable.
