### PR TITLE
chore: pin lti version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,6 @@
 
 # Common constraints for edx repos
 -c common_constraints.txt
+
+# 9.13.0 includes a bug for LTI 1.3 launches
+lti-consumer-xblock < 9.13.0


### PR DESCRIPTION
Version 9.13.0 breaks LTI 1.3 launches. Until a new version of the package is released, the version needs to be pinned.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
