### PR TITLE
chore: remove lti constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,6 +10,3 @@
 
 # Common constraints for edx repos
 -c common_constraints.txt
-
-# 9.13.0 includes a bug for LTI 1.3 launches
-lti-consumer-xblock < 9.13.0


### PR DESCRIPTION
Version 9.13.1 contains a fix for LTI 1.3 launches, so this constraint should be removed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
