### PR TITLE
feat: add middleware routing for onboarding endpoint

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -1996,3 +1996,46 @@ class AllowanceViewTests(ExamsAPITestCase):
         ]
         response = self.request_api('post', self.user, self.exam.course_id, data=request_data)
         self.assertEqual(response.status_code, 400)
+
+
+class UserOnboardingViewTest(ExamsAPITestCase):
+    """
+    Tests UserOnboardingView
+    """
+    def setUp(self):
+        super().setUp()
+
+        self.course_id = 'course-v1:edx+test+f19'
+        CourseExamConfigurationFactory.create(course_id=self.course_id)
+
+    def get_api(self):
+        """
+        Helper function to make patch request to the API
+        """
+
+        headers = self.build_jwt_headers(self.user)
+        url = reverse(
+            'api:v1:student-onboarding',
+            kwargs={'course_id': self.course_id}
+        )
+
+        return self.client.get(url, **headers)
+
+    def test_auth_required(self):
+        """
+        Test endpoint requires authentication
+        """
+
+        # no auth
+        response = self.client.get(
+            reverse('api:v1:student-onboarding', kwargs={'course_id': self.course_id}),
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_404_response(self):
+        """
+        Test that endpoint returns 404 response
+        """
+
+        response = self.get_api()
+        self.assertEqual(response.status_code, 404)

--- a/edx_exams/apps/api/v1/urls.py
+++ b/edx_exams/apps/api/v1/urls.py
@@ -12,7 +12,8 @@ from edx_exams.apps.api.v1.views import (
     InstructorAttemptsListView,
     LatestExamAttemptView,
     ProctoringProvidersView,
-    ProctoringSettingsView
+    ProctoringSettingsView,
+    UserOnboardingView
 )
 from edx_exams.apps.core.constants import COURSE_ID_PATTERN, EXAM_ID_PATTERN, USAGE_KEY_PATTERN
 
@@ -78,5 +79,10 @@ urlpatterns = [
         fr'exam/provider_settings/course_id/{COURSE_ID_PATTERN}/exam_id/{EXAM_ID_PATTERN}',
         ProctoringSettingsView.as_view(),
         name='proctoring-settings'
+    ),
+    re_path(
+        fr'student/course_id/{COURSE_ID_PATTERN}/onboarding',
+        UserOnboardingView.as_view(),
+        name='student-onboarding'
     ),
 ]

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -885,3 +885,21 @@ class AllowanceView(ExamsAPIView):
             response_status = status.HTTP_400_BAD_REQUEST
             data = {'detail': 'Invalid data', 'errors': serializer.errors}
             return Response(status=response_status, data=data)
+
+
+class UserOnboardingView(ExamsAPIView):
+    """
+    Endpoint to retrieve onboarding data. Note that onboarding exams are not currently supported
+    in edx-exams, but this endpoint has been created for middleware requests to edx-proctoring
+
+    student/course_id/{course_id}/onboarding
+    """
+
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, course_id):  # pylint: disable=unused-argument
+        """
+        HTTP GET handler. Returns a 404 as onboarding is not currently supported in the edx-exams service.
+        """
+        return Response(status=status.HTTP_404_NOT_FOUND)

--- a/edx_exams/apps/router/interop.py
+++ b/edx_exams/apps/router/interop.py
@@ -18,6 +18,7 @@ LMS_PROCTORED_EXAM_ACTIVE_ATTEMPT_API_TPL = 'proctored_exam/active_attempt?user_
 LMS_PROCTORED_EXAM_ATTEMPT_DATA_API_TPL = 'proctored_exam/attempt/course_id/{}?content_id={}&user_id={}'
 LMS_PROCTORED_EXAM_ATTEMPT_API = 'proctored_exam/attempt'
 LMS_PROCTORED_EXAM_PROVIDER_SETTINGS_API_TPL = 'proctored_exam/settings/exam_id/{}/'
+LMS_PROCTORED_EXAM_ONBOARDING_DATA_API_TPL = 'user_onboarding/status?is_learning_mfe=true&course_id={}'
 
 log = logging.getLogger(__name__)
 
@@ -78,6 +79,27 @@ def get_provider_settings(exam_id):
     response_data = _get_json_data(response)
     if response.status_code != status.HTTP_200_OK:
         log.error(f'Failed to get provider settings, response was {response.content}')
+
+    return response_data, response.status_code
+
+
+def get_user_onboarding_data(course_id, username=None):
+    """
+    Get user onboarding data given a course_id and optional username
+    """
+    template = LMS_PROCTORED_EXAM_ONBOARDING_DATA_API_TPL
+
+    if username:
+        template += '&username={}'
+        path = template.format(course_id, username)
+    else:
+        path = template.format(course_id)
+
+    response = _make_proctoring_request(path, 'GET')
+
+    response_data = _get_json_data(response)
+    if response.status_code != status.HTTP_200_OK:
+        log.error(f'Failed to get onboarding data, response was {response.content}')
 
     return response_data, response.status_code
 

--- a/edx_exams/apps/router/middleware.py
+++ b/edx_exams/apps/router/middleware.py
@@ -6,9 +6,19 @@ import logging
 
 from django.utils.deprecation import MiddlewareMixin
 
-from edx_exams.apps.api.v1.views import CourseExamAttemptView, CourseExamsView, ProctoringSettingsView
+from edx_exams.apps.api.v1.views import (
+    CourseExamAttemptView,
+    CourseExamsView,
+    ProctoringSettingsView,
+    UserOnboardingView
+)
 from edx_exams.apps.core.models import CourseExamConfiguration
-from edx_exams.apps.router.views import CourseExamAttemptLegacyView, CourseExamsLegacyView, ProctoringSettingsLegacyView
+from edx_exams.apps.router.views import (
+    CourseExamAttemptLegacyView,
+    CourseExamsLegacyView,
+    ProctoringSettingsLegacyView,
+    UserOnboardingLegacyView
+)
 
 log = logging.getLogger(__name__)
 
@@ -16,6 +26,7 @@ LEGACY_VIEW_MAP = {
     CourseExamsView: CourseExamsLegacyView,
     CourseExamAttemptView: CourseExamAttemptLegacyView,
     ProctoringSettingsView: ProctoringSettingsLegacyView,
+    UserOnboardingView: UserOnboardingLegacyView
 }
 
 

--- a/edx_exams/apps/router/views.py
+++ b/edx_exams/apps/router/views.py
@@ -13,7 +13,12 @@ from rest_framework.views import APIView
 
 from edx_exams.apps.api.permissions import CourseStaffUserPermissions
 from edx_exams.apps.core.exam_types import get_exam_type
-from edx_exams.apps.router.interop import get_provider_settings, get_student_exam_attempt_data, register_exams
+from edx_exams.apps.router.interop import (
+    get_provider_settings,
+    get_student_exam_attempt_data,
+    get_user_onboarding_data,
+    register_exams
+)
 
 log = logging.getLogger(__name__)
 
@@ -97,6 +102,28 @@ class ProctoringSettingsLegacyView(APIView):
         Get provider settings given an exam ID. Pass through the response from edx-proctoring directly
         """
         response_data, response_status = get_provider_settings(exam_id)
+
+        return JsonResponse(
+            data=response_data,
+            status=response_status,
+            safe=False
+        )
+
+
+class UserOnboardingLegacyView(APIView):
+    """
+    View to handle user onboarding for exams managed by edx-proctoring
+    """
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request, course_id):
+        """
+        Get user onboarding data given course_id and an optional username
+        """
+        username = request.GET.get('username')
+
+        response_data, response_status = get_user_onboarding_data(course_id, username)
 
         return JsonResponse(
             data=response_data,


### PR DESCRIPTION
**JIRA:** https://2u-internal.atlassian.net/browse/COSMO-623

**Description:** This PR adds support to route onboarding requests to the edx-proctoring backend via the edx-exams middleware. Because edx-exams does not support onboarding exams at this point, any requests routed to the edx-exams backend will return a 404 response.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
