### PR TITLE
fix: encode course id and username for lms request

### DIFF
--- a/edx_exams/apps/router/interop.py
+++ b/edx_exams/apps/router/interop.py
@@ -88,12 +88,14 @@ def get_user_onboarding_data(course_id, username=None):
     Get user onboarding data given a course_id and optional username
     """
     template = LMS_PROCTORED_EXAM_ONBOARDING_DATA_API_TPL
+    url_safe_course_id = quote_plus(course_id)
 
     if username:
         template += '&username={}'
-        path = template.format(course_id, username)
+        url_safe_username = quote_plus(username)
+        path = template.format(url_safe_course_id, url_safe_username)
     else:
-        path = template.format(course_id)
+        path = template.format(url_safe_course_id)
 
     response = _make_proctoring_request(path, 'GET')
 

--- a/edx_exams/apps/router/tests/test_interop.py
+++ b/edx_exams/apps/router/tests/test_interop.py
@@ -159,8 +159,8 @@ class LegacyInteropTest(TestCase):
     @ddt.data(
         (200, None),
         (422, None),
-        (200, 'edx'),
-        (422, 'edx')
+        (200, 'edx@edx.org'),
+        (422, 'edx@edx.org')
     )
     @mock_oauth_login
     @responses.activate
@@ -171,12 +171,15 @@ class LegacyInteropTest(TestCase):
         HTTP exceptions are handled and response is returned for
         non-200 states codes
         """
+        url_course_id = 'course-v1%3Aedx%2Btest%2Bf19'
+        url_username = 'edx%40edx.org'
+
         self.lms_url = (
             f'{settings.LMS_ROOT_URL}/api/edx_proctoring/v1/user_onboarding/status'
-            f'?is_learning_mfe=true&course_id={self.course_id}'
+            f'?is_learning_mfe=true&course_id={url_course_id}'
         )
         if username:
-            self.lms_url += f'&username={username}'
+            self.lms_url += f'&username={url_username}'
 
         responder = responses.add(
             responses.GET,


### PR DESCRIPTION
Query and path parameters need to be re-encoded before being included in requests to the LMS.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
