### PR TITLE
fix: grant course staff exam access tokens

### DIFF
--- a/edx_exams/apps/api/v1/tests/test_views.py
+++ b/edx_exams/apps/api/v1/tests/test_views.py
@@ -815,6 +815,26 @@ class ExamAccessTokensViewsTests(ExamsAPITestCase):
         if response_status == 200:
             self.assert_valid_exam_access_token(response, self.user, no_due_date_exam)
 
+    def test_access_user_is_course_staff(self):
+        """
+        Verify the endpoint grants access for an exam
+        with no due date, if started exam attempt.
+        """
+        allowed_time_limit_mins = self.exam.time_limit_mins
+        start_time = timezone.now() - timedelta(minutes=allowed_time_limit_mins/2)
+        ExamAttempt.objects.create(
+            user=self.user,
+            exam=self.exam,
+            attempt_number=1,
+            status='started',
+            start_time=start_time,
+            allowed_time_limit_mins=allowed_time_limit_mins
+        )
+
+        response = self.get_exam_access(self.user, self.url)
+        self.assertEqual(200, response.status_code)
+        self.assert_valid_exam_access_token(response, self.user, self.exam)
+
     def test_access_not_granted_if_hide_after_due(self):
         """
         Verify the endpoint does not grant access for past-due exam

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -318,9 +318,10 @@ class ExamAccessTokensView(ExamsAPIView):
     View to create signed exam access tokens for a specific user and exam.
 
     Given an exam_id and user (in request), this view will either grant access
-    as an exam access token or not grant access. Access is granted if there is an
-    existing exam attempt (must be started if no due date or prior to due date or
-    verified if past the due date.) or if the exam is past its due date.
+    as an exam access token or not grant access. Access is granted if the requesting
+    user is course staff, if there is an existing exam attempt (must be started if
+    no due date or prior to due date or verified if past the due date), or if the
+    exam is past its due date.
 
     HTTP GET
     Provides an Exam Access Token as a cookie if access is granted.

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -365,8 +365,12 @@ class ExamAccessTokensView(ExamsAPIView):
         grant_access = False
         response_status = status.HTTP_403_FORBIDDEN
 
+        # If user is course staff, then grant them access
+        if user.has_course_staff_permission(exam.course_id):
+            grant_access, response_status = True, status.HTTP_200_OK
+
         # If exam attempt exists for user, then grant exam access
-        if exam_attempt is not None:
+        elif exam_attempt is not None:
             # If no due date or if before due date, grant access if attempt started
             # and get expiration window.
             if exam.due_date is None or timezone.now() < exam.due_date:
@@ -383,10 +387,6 @@ class ExamAccessTokensView(ExamsAPIView):
 
         # If exam is past the due date, then grant exam access
         elif exam.due_date is not None and timezone.now() >= exam.due_date:
-            grant_access, response_status = True, status.HTTP_200_OK
-
-        # If user is course staff, then grant them access
-        elif user.has_course_staff_permission(exam.course_id):
             grant_access, response_status = True, status.HTTP_200_OK
 
         if grant_access:

--- a/edx_exams/apps/api/v1/views.py
+++ b/edx_exams/apps/api/v1/views.py
@@ -385,6 +385,10 @@ class ExamAccessTokensView(ExamsAPIView):
         elif exam.due_date is not None and timezone.now() >= exam.due_date:
             grant_access, response_status = True, status.HTTP_200_OK
 
+        # If user is course staff, then grant them access
+        elif user.has_course_staff_permission(exam.course_id):
+            grant_access, response_status = True, status.HTTP_200_OK
+
         if grant_access:
             log.info('Creating exam access token')
             access_token = sign_token_for(user.lms_user_id, expiration_window, claims)


### PR DESCRIPTION
**JIRA:** [Link to JIRA ticket](https://2u-internal.atlassian.net/browse/CR-7304)

**Description:** Add a fix to allow course staff to view the exams they create, as currently some courses staff are blocked from viewing the exams they've created.

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.

**Dependencies:** dependencies on other outstanding PRs, issues, etc. 

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**

1. Open page A
2. Do thing B
3. Expect C to happen
4. If D happened instead - check failed.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Delete working branch (if not needed anymore)
