### PR TITLE
refactor: update deprecated requestmetric middleware

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -75,7 +75,7 @@ MIDDLEWARE = (
     # Enables force_django_cache_miss functionality for TieredCache.
     'edx_django_utils.cache.middleware.TieredCacheMiddleware',
     # Outputs monitoring metrics for a request.
-    'edx_rest_framework_extensions.middleware.RequestMetricsMiddleware',
+    'edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware',
     # Ensures proper DRF permissions in support of JWTs
     'edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware',
     'edx_exams.apps.router.middleware.ExamRequestMiddleware'


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/815
- The middleware was [deprecated/renamed](https://github.com/openedx/edx-drf-extensions/blob/2b4347518680046aa54caa404c030d0ffe308acf/CHANGELOG.rst#620---2020-08-24) in the `edx-drf-extensions==6.2.0` but was pending to be updated.