### PR TITLE
refactor: update deprecated MonitoringCustomMetricsMiddleware

### DIFF
--- a/edx_exams/settings/base.py
+++ b/edx_exams/settings/base.py
@@ -59,7 +59,7 @@ MIDDLEWARE = (
     # Resets RequestCache utility for added safety.
     'edx_django_utils.cache.middleware.RequestCacheMiddleware',
     # Enables monitoring utility for writing custom metrics.
-    'edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware',
+    'edx_django_utils.monitoring.CachedCustomMonitoringMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/815
- `edx_django_utils.monitoring.middleware.MonitoringCustomMetricsMiddleware` has been deprecated for a while and has been replaced with `edx_django_utils.monitoring.CachedCustomMonitoringMiddleware`