### PR TITLE
Adding new port 2010 for frontend-app-learning due to codespace port collision on 2000 port

### DIFF
--- a/edx_exams/settings/local.py
+++ b/edx_exams/settings/local.py
@@ -120,8 +120,8 @@ SESSION_COOKIE_DOMAIN = 'localhost'
 ROOT_URL = 'http://localhost:18740'
 LTI_API_BASE = 'http://localhost:18740'
 LMS_ROOT_URL = 'http://localhost:18000'
-LEARNING_MICROFRONTEND_URL = 'http://localhost:2000'
-LTI_CUSTOM_URL_CLAIM = 'http://localhost:2000'
+LEARNING_MICROFRONTEND_URL = 'http://localhost:2010'
+LTI_CUSTOM_URL_CLAIM = 'http://localhost:2010'
 EXAMS_DASHBOARD_MFE_URL = 'http://localhost:2020'
 
 CORS_ORIGIN_WHITELIST = (


### PR DESCRIPTION
**JIRA:** : https://2u-internal.atlassian.net/browse/AU-2523

**Description:** Codespaces devstack has a collision with Learning MFE for port 2000

**Dependencies:** Connected PR:  https://github.com/edx/devstack/pull/150
