### PR TITLE
chore: removal of pyjwkest from edx-exams

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   django
     #   django-cors-headers
@@ -17,13 +17,13 @@ attrs==25.3.0
     #   openedx-events
 bleach==6.2.0
     # via lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
     #   boto3
     #   s3transfer
-certifi==2025.4.26
+certifi==2025.8.3
     # via requests
 cffi==1.17.1
     # via
@@ -43,7 +43,7 @@ coreapi==2.3.3
     #   openapi-codec
 coreschema==0.0.4
     # via coreapi
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   edx-token-utils
     #   pyjwt
@@ -54,7 +54,7 @@ defusedxml==0.7.1
     #   social-auth-core
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/base.in
     #   django-appconf
     #   django-config-models
@@ -102,7 +102,7 @@ django-model-utils==5.0.0
     # via -r requirements/base.in
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
-django-simple-history==3.8.0
+django-simple-history==3.10.1
     # via -r requirements/base.in
 django-statici18n==2.6.0
     # via lti-consumer-xblock
@@ -112,7 +112,7 @@ django-waffle==5.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -129,7 +129,7 @@ drf-yasg==1.21.10
     # via edx-api-doc-tools
 edx-api-doc-tools==2.1.0
     # via -r requirements/base.in
-edx-auth-backends==4.5.0
+edx-auth-backends==4.6.0
     # via -r requirements/base.in
 edx-ccx-keys==2.0.2
     # via
@@ -141,6 +141,7 @@ edx-django-utils==8.0.0
     # via
     #   -r requirements/base.in
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -163,13 +164,14 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
 edx-rest-api-client==6.2.0
     # via -r requirements/base.in
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
     # via -r requirements/base.in
-fastavro==1.11.1
+fastavro==1.12.0
     # via openedx-events
 fs==2.4.16
     # via
@@ -178,8 +180,6 @@ fs==2.4.16
     #   xblock
 fs-s3fs==1.1.1
     # via openedx-django-pyfs
-future==1.0.0
-    # via pyjwkest
 idna==3.10
     # via requests
 inflection==0.5.1
@@ -194,13 +194,13 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via lti-consumer-xblock
 lazy==1.6
     # via lti-consumer-xblock
-lti-consumer-xblock==9.14.0
+lti-consumer-xblock==9.14.2
     # via -r requirements/base.in
-lxml==5.4.0
+lxml==6.0.0
     # via
     #   lti-consumer-xblock
     #   xblock
@@ -215,7 +215,7 @@ markupsafe==3.0.2
     #   xblock
 mysqlclient==2.2.7
     # via -r requirements/base.in
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
     #   lti-consumer-xblock
     #   requests-oauthlib
@@ -224,7 +224,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
     #   -r requirements/base.in
     #   edx-event-bus-kafka
@@ -240,10 +240,6 @@ psutil==7.0.0
 pycparser==2.22
     # via cffi
 pycryptodomex==3.23.0
-    # via
-    #   lti-consumer-xblock
-    #   pyjwkest
-pyjwkest==1.4.2
     # via lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
@@ -256,7 +252,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.in
-pymongo==4.13.1
+pymongo==4.14.0
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -279,19 +275,18 @@ pyyaml==6.0.2
     #   drf-yasg
     #   edx-django-release-util
     #   xblock
-redis==6.2.0
+redis==6.4.0
     # via walrus
 requests==2.32.4
     # via
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
@@ -306,11 +301,10 @@ six==1.17.0
     #   edx-django-release-util
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 social-auth-app-django==5.4.3
     # via edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -323,18 +317,17 @@ stevedore==5.4.1
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via edx-opaque-keys
 uritemplate==4.2.0
     # via
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
     #   botocore
     #   requests
-walrus==0.9.4
+walrus==0.9.5
     # via edx-event-bus-redis
 web-fragments==3.1.0
     # via xblock

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-cachetools==6.0.0
+cachetools==6.1.0
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-coverage==7.9.0
+coverage==7.10.2
     # via -r requirements/ci.in
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 filelock==3.18.0
     # via
@@ -30,7 +30,7 @@ pluggy==1.6.0
     # via tox
 pyproject-api==1.9.1
     # via tox
-tox==4.26.0
+tox==4.28.4
     # via -r requirements/ci.in
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -20,13 +20,6 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,66 +6,66 @@
 #
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django
     #   django-cors-headers
-astroid==3.3.10
+astroid==3.3.11
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   boto3
     #   s3transfer
-build==1.2.2.post1
+build==1.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==6.0.0
+cachetools==6.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   tox
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   diff-cover
     #   tox
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/validation.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -73,57 +73,57 @@ click==8.2.1
     #   pip-tools
 click-log==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-lint
     #   edx-toggles
 colorama==0.4.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   tox
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   coreapi
-coverage[toml]==7.9.0
+coverage[toml]==7.10.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-token-utils
     #   pyjwt
     #   secretstorage
     #   social-auth-core
 ddt==1.7.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==9.3.2
+diff-cover==9.6.0
     # via -r requirements/dev.in
 dill==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   virtualenv
 django==4.2.23
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -156,48 +156,48 @@ django==4.2.23
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-toggles
-django-debug-toolbar==5.2.0
+django-debug-toolbar==6.0.0
     # via -r requirements/dev.in
 django-dynamic-fixture==4.0.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 django-extensions==4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 django-rest-swagger==2.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-django-simple-history==3.8.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
+django-simple-history==3.10.1
+    # via -r requirements/validation.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -206,35 +206,36 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pymongo
-docutils==0.21.2
+docutils==0.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   readme-renderer
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-edx-auth-backends==4.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
+edx-auth-backends==4.6.0
+    # via -r requirements/validation.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -242,132 +243,129 @@ edx-django-utils==8.0.0
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 edx-event-bus-kafka==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 edx-event-bus-redis==0.6.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
 edx-lint==5.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
     #   openedx-events
     #   openedx-filters
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-edx-toggles==5.3.0
+    # via -r requirements/validation.txt
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 factory-boy==3.3.3
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-faker==37.4.0
+    # via -r requirements/validation.txt
+faker==37.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   openedx-events
 filelock==3.18.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   tox
     #   virtualenv
-freezegun==1.5.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+freezegun==1.5.4
+    # via -r requirements/validation.txt
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-    #   pyjwkest
 id==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   coreapi
 jaraco-classes==3.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   keyring
 jeepney==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   keyring
     #   secretstorage
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   code-annotations
     #   coreschema
     #   diff-cover
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 keyring==25.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-lxml[html-clean]==5.4.0
+lti-consumer-xblock==9.14.2
+    # via -r requirements/validation.txt
+lxml[html-clean]==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-i18n-tools
     #   lti-consumer-xblock
     #   lxml-html-clean
@@ -376,67 +374,67 @@ lxml-html-clean==0.4.2
     # via lxml
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
     #   xblock
 markdown-it-py==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   rich
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   jinja2
     #   mako
     #   xblock
 mccabe==0.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   markdown-it-py
 mock==5.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 more-itertools==10.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   jaraco-classes
     #   jaraco-functools
 mysqlclient==2.2.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-nh3==0.2.21
+    # via -r requirements/validation.txt
+nh3==0.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   readme-renderer
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/validation.txt
     #   build
     #   drf-yasg
     #   pyproject-api
@@ -447,55 +445,51 @@ path==16.16.0
     # via edx-i18n-tools
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   stevedore
-pip-tools==7.4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
+pip-tools==7.5.0
+    # via -r requirements/pip-tools.txt
 platformdirs==4.3.8
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   diff-cover
     #   pytest
+    #   pytest-cov
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-django-utils
-pycodestyle==2.13.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+pycodestyle==2.14.0
+    # via -r requirements/validation.txt
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
-    #   pyjwkest
 pydocstyle==6.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-pygments==2.19.1
+    # via -r requirements/validation.txt
+pygments==2.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   diff-cover
     #   pytest
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-    #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -505,74 +499,74 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pylint==3.3.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint-celery
     #   pylint-django
 pymemcache==4.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-pymongo==4.13.1
+    # via -r requirements/validation.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-django-utils
 pyproject-api==1.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.4.0
+pytest==8.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+pytest-cov==6.2.1
+    # via -r requirements/validation.txt
 pytest-django==4.11.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   botocore
     #   freezegun
     #   xblock
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
@@ -581,20 +575,19 @@ pyyaml==6.0.2
     #   xblock
 readme-renderer==44.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -602,133 +595,132 @@ requests==2.32.4
     #   twine
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
 responses==0.25.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    # via -r requirements/validation.txt
 rfc3986==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
-rich==14.0.0
+rich==14.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   twine
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   boto3
 secretstorage==3.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   keyring
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 snowballstemmer==3.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pydocstyle
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   django
     #   django-debug-toolbar
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   python-slugify
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   pylint
-tox==4.26.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+tox==4.28.4
+    # via -r requirements/validation.txt
 twine==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
-typing-extensions==4.14.0
+    # via -r requirements/validation.txt
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-opaque-keys
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   faker
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   botocore
     #   requests
     #   responses
     #   twine
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   tox
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   xblock
 wheel==0.45.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/validation.txt
+    #   -r requirements/validation.txt
     #   lti-consumer-xblock
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,120 +8,120 @@ alabaster==0.7.16
     # via sphinx
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
     #   django-cors-headers
-astroid==3.3.10
+astroid==3.3.11
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 babel==2.17.0
     # via sphinx
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-build==1.2.2.post1
+build==1.3.0
     # via -r requirements/doc.in
-cachetools==6.0.0
+cachetools==6.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
 colorama==0.4.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.9.0
+coverage[toml]==7.10.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-token-utils
     #   pyjwt
     #   secretstorage
     #   social-auth-core
 ddt==1.7.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
 dill==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   virtualenv
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -152,46 +152,46 @@ django==4.2.23
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
 django-dynamic-fixture==4.0.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-extensions==4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-rest-swagger==2.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-django-simple-history==3.8.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
+django-simple-history==3.10.1
+    # via -r requirements/test.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -200,9 +200,9 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pymongo
-doc8==1.1.2
+doc8==2.0.0
     # via -r requirements/doc.in
 docutils==0.19
     # via
@@ -212,27 +212,28 @@ docutils==0.19
     #   sphinx
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-edx-auth-backends==4.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
+edx-auth-backends==4.6.0
+    # via -r requirements/test.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -240,92 +241,89 @@ edx-django-utils==8.0.0
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-event-bus-kafka==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-event-bus-redis==0.6.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-lint==5.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
     #   openedx-events
     #   openedx-filters
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-sphinx-theme==3.1.0
     # via -r requirements/doc.in
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 factory-boy==3.3.3
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-faker==37.4.0
+    # via -r requirements/test.txt
+faker==37.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   openedx-events
 filelock==3.18.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+freezegun==1.5.4
+    # via -r requirements/test.txt
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   pyjwkest
 id==1.5.0
     # via twine
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 imagesize==1.4.1
     # via sphinx
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.2.1
     # via keyring
 jeepney==0.9.0
     # via
@@ -333,87 +331,87 @@ jeepney==0.9.0
     #   secretstorage
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
     #   sphinx
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 keyring==25.6.0
     # via twine
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-lxml==5.4.0
+lti-consumer-xblock==9.14.2
+    # via -r requirements/test.txt
+lxml==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   jinja2
     #   mako
     #   xblock
 mccabe==0.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 mysqlclient==2.2.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-nh3==0.2.21
+    # via -r requirements/test.txt
+nh3==0.3.0
     # via readme-renderer
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   build
     #   drf-yasg
     #   pyproject-api
@@ -423,47 +421,43 @@ packaging==25.0
     #   twine
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   stevedore
 platformdirs==4.3.8
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
+    #   pytest-cov
     #   tox
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-    #   pyjwkest
-pygments==2.19.1
+pygments==2.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   doc8
     #   pytest
     #   readme-renderer
     #   rich
     #   sphinx
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -473,71 +467,71 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pylint==3.3.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
 pymemcache==4.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-pymongo==4.13.1
+    # via -r requirements/test.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-api==1.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
 pyproject-hooks==1.2.0
     # via build
-pytest==8.4.0
+pytest==8.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+pytest-cov==6.2.1
+    # via -r requirements/test.txt
 pytest-django==4.11.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   botocore
     #   freezegun
     #   xblock
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
@@ -545,18 +539,17 @@ pyyaml==6.0.2
     #   xblock
 readme-renderer==43.0
     # via twine
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -565,36 +558,36 @@ requests==2.32.4
     #   twine
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
 responses==0.25.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via doc8
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.1.0
     # via twine
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
 secretstorage==3.3.3
     # via keyring
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
@@ -602,17 +595,16 @@ six==1.17.0
     #   edx-sphinx-theme
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 snowballstemmer==3.0.1
     # via sphinx
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sphinx==5.3.0
@@ -633,71 +625,70 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   doc8
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   python-slugify
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
-tox==4.26.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+tox==4.28.4
+    # via -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/doc.in
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   faker
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   botocore
     #   requests
     #   responses
     #   twine
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   xblock
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
 click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.45.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.1.1
+pip==25.2
     # via -r requirements/pip.in
 setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -6,77 +6,77 @@
 #
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
     #   django-cors-headers
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-ses
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-toggles
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-token-utils
     #   pyjwt
     #   social-auth-core
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
 django==4.2.23
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -108,46 +108,46 @@ django==4.2.23
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
 django-extensions==4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-rest-swagger==2.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-ses==4.4.0
     # via -r requirements/production.in
-django-simple-history==3.8.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+django-simple-history==3.10.1
+    # via -r requirements/base.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -156,31 +156,32 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-edx-auth-backends==4.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
+edx-auth-backends==4.6.0
+    # via -r requirements/base.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -188,46 +189,43 @@ edx-django-utils==8.0.0
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-event-bus-kafka==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-event-bus-redis==0.6.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
     #   openedx-events
     #   openedx-filters
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-edx-toggles==5.3.0
+    # via -r requirements/base.txt
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-fastavro==1.11.1
+    # via -r requirements/base.txt
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   openedx-events
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-    #   pyjwkest
 gevent==25.5.1
     # via -r requirements/production.in
 greenlet==3.2.3
@@ -236,108 +234,103 @@ gunicorn==23.0.0
     # via -r requirements/production.in
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-lxml==5.4.0
+lti-consumer-xblock==9.14.2
+    # via -r requirements/base.txt
+lxml==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   jinja2
     #   mako
     #   xblock
 mysqlclient==2.2.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   -r requirements/production.in
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
     #   gunicorn
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   stevedore
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-    #   lti-consumer-xblock
-    #   pyjwkest
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -346,141 +339,139 @@ pyjwt[crypto]==2.10.1
     #   lti-consumer-xblock
     #   social-auth-core
 pymemcache==4.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-pymongo==4.13.1
+    # via -r requirements/base.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   botocore
     #   xblock
 python-memcached==1.62
     # via -r requirements/production.in
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   -r requirements/production.in
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
     #   xblock
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   social-auth-core
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-opaque-keys
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   botocore
     #   requests
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   xblock
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-zope-event==5.0
+zope-event==5.1.1
     # via gevent
 zope-interface==7.2
     # via gevent

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -6,116 +6,116 @@
 #
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
     #   django-cors-headers
-astroid==3.3.10
+astroid==3.3.11
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==6.0.0
+cachetools==6.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
 colorama==0.4.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.9.0
+coverage[toml]==7.10.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-token-utils
     #   pyjwt
     #   secretstorage
     #   social-auth-core
 ddt==1.7.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
 dill==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   virtualenv
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -146,46 +146,46 @@ django==4.2.23
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
 django-dynamic-fixture==4.0.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-extensions==4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 django-rest-swagger==2.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-django-simple-history==3.8.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
+django-simple-history==3.10.1
+    # via -r requirements/test.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -194,33 +194,34 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pymongo
-docutils==0.21.2
+docutils==0.22
     # via readme-renderer
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-edx-auth-backends==4.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
+edx-auth-backends==4.6.0
+    # via -r requirements/test.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -228,91 +229,88 @@ edx-django-utils==8.0.0
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-event-bus-kafka==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-event-bus-redis==0.6.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 edx-lint==5.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
     #   -r requirements/quality.in
+    #   -r requirements/test.txt
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
     #   openedx-events
     #   openedx-filters
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-edx-toggles==5.3.0
+    # via -r requirements/test.txt
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 factory-boy==3.3.3
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-faker==37.4.0
+    # via -r requirements/test.txt
+faker==37.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   openedx-events
 filelock==3.18.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.2
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+freezegun==1.5.4
+    # via -r requirements/test.txt
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   pyjwkest
 id==1.5.0
     # via twine
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
     #   -r requirements/quality.in
+    #   -r requirements/test.txt
     #   pylint
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
 jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.2.1
     # via keyring
 jeepney==0.9.0
     # via
@@ -320,86 +318,86 @@ jeepney==0.9.0
     #   secretstorage
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 keyring==25.6.0
     # via twine
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-lxml==5.4.0
+lti-consumer-xblock==9.14.2
+    # via -r requirements/test.txt
+lxml==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   jinja2
     #   mako
     #   xblock
 mccabe==0.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
 mdurl==0.1.2
     # via markdown-it-py
 mock==5.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
 mysqlclient==2.2.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-nh3==0.2.21
+    # via -r requirements/test.txt
+nh3==0.3.0
     # via readme-renderer
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   pyproject-api
     #   pytest
@@ -407,49 +405,45 @@ packaging==25.0
     #   twine
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   stevedore
 platformdirs==4.3.8
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
+    #   pytest-cov
     #   tox
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.13.0
+pycodestyle==2.14.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-    #   pyjwkest
 pydocstyle==6.3.0
     # via -r requirements/quality.in
-pygments==2.19.1
+pygments==2.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -459,69 +453,69 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pylint==3.3.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
 pymemcache==4.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-pymongo==4.13.1
+    # via -r requirements/test.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-api==1.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
-pytest==8.4.0
+pytest==8.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+pytest-cov==6.2.1
+    # via -r requirements/test.txt
 pytest-django==4.11.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   botocore
     #   freezegun
     #   xblock
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
@@ -529,18 +523,17 @@ pyyaml==6.0.2
     #   xblock
 readme-renderer==44.0
     # via twine
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -548,119 +541,117 @@ requests==2.32.4
     #   twine
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via twine
 responses==0.25.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    # via -r requirements/test.txt
 rfc3986==2.0.0
     # via twine
-rich==14.0.0
+rich==14.1.0
     # via twine
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   boto3
 secretstorage==3.3.3
     # via keyring
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 snowballstemmer==3.0.1
     # via pydocstyle
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   python-slugify
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   pylint
-tox==4.26.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+tox==4.28.4
+    # via -r requirements/test.txt
 twine==6.1.0
     # via -r requirements/quality.in
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   faker
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   botocore
     #   requests
     #   responses
     #   twine
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   tox
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   xblock
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,55 +6,55 @@
 #
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
     #   django-cors-headers
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
     #   s3transfer
-cachetools==6.0.0
+cachetools==6.1.0
     # via tox
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   cryptography
     #   pynacl
 chardet==5.2.0
     # via tox
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -63,7 +63,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   -r requirements/test.in
     #   edx-lint
     #   edx-toggles
@@ -71,20 +71,20 @@ colorama==0.4.6
     # via tox
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
-coverage[toml]==7.9.0
+coverage[toml]==7.10.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-token-utils
     #   pyjwt
     #   social-auth-core
@@ -92,16 +92,16 @@ ddt==1.7.2
     # via -r requirements/test.in
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
 dill==0.4.0
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/base.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -132,46 +132,46 @@ distlib==0.3.9
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via -r requirements/test.in
 django-extensions==4.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 django-rest-swagger==2.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-django-simple-history==3.8.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
+django-simple-history==3.10.1
+    # via -r requirements/base.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -180,31 +180,32 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-edx-auth-backends==4.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
+edx-auth-backends==4.6.0
+    # via -r requirements/base.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -212,65 +213,62 @@ edx-django-utils==8.0.0
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.6.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-event-bus-kafka==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-event-bus-redis==0.6.1
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 edx-lint==5.6.0
     # via -r requirements/test.in
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
     #   openedx-events
     #   openedx-filters
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-edx-toggles==5.3.0
+    # via -r requirements/base.txt
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    # via -r requirements/base.txt
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==37.4.0
+faker==37.5.3
     # via factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   openedx-events
 filelock==3.18.0
     # via
     #   tox
     #   virtualenv
-freezegun==1.5.2
+freezegun==1.5.4
     # via -r requirements/test.in
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-    #   pyjwkest
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via pytest
@@ -278,41 +276,41 @@ isort==6.0.1
     # via pylint
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-lxml==5.4.0
+lti-consumer-xblock==9.14.2
+    # via -r requirements/base.txt
+lxml==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   xblock
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   jinja2
     #   mako
     #   xblock
@@ -321,40 +319,40 @@ mccabe==0.7.0
 mock==5.2.0
     # via -r requirements/test.in
 mysqlclient==2.2.7
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-oauthlib==3.2.2
+    # via -r requirements/base.txt
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
     #   pyproject-api
     #   pytest
     #   tox
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   stevedore
 platformdirs==4.3.8
     # via
@@ -364,29 +362,25 @@ platformdirs==4.3.8
 pluggy==1.6.0
     # via
     #   pytest
+    #   pytest-cov
     #   tox
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
-    #   pyjwkest
-pygments==2.19.1
+pygments==2.19.2
     # via pytest
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-    #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -404,167 +398,164 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.6.1
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
 pymemcache==4.0.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
-pymongo==4.13.1
+    # via -r requirements/base.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-django-utils
 pyproject-api==1.9.1
     # via tox
-pytest==8.4.0
+pytest==8.4.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.0
+pytest-cov==6.2.1
     # via -r requirements/test.in
 pytest-django==4.11.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   botocore
     #   freezegun
     #   xblock
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
     #   responses
     #   xblock
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   responses
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   social-auth-core
 responses==0.25.7
     # via -r requirements/test.in
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   boto3
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   python-slugify
 tomlkit==0.13.3
     # via pylint
-tox==4.26.0
+tox==4.28.4
     # via -r requirements/test.in
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-opaque-keys
 tzdata==2025.2
     # via faker
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c /home/runner/work/edx-exams/edx-exams/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   botocore
     #   requests
     #   responses
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via tox
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   xblock
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/base.txt
+    #   -r requirements/base.txt
     #   lti-consumer-xblock
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -6,141 +6,141 @@
 #
 appdirs==1.4.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   fs
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django
     #   django-cors-headers
-astroid==3.3.10
+astroid==3.3.11
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-boto3==1.38.35
+boto3==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
-botocore==1.38.35
+botocore==1.40.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   boto3
     #   s3transfer
-cachetools==6.0.0
+cachetools==6.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
-certifi==2025.4.26
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   cryptography
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
 charset-normalizer==3.4.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   requests
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
     #   edx-lint
 click-log==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-lint
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
 colorama==0.4.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
 coreapi==2.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   openapi-codec
 coreschema==0.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   coreapi
-coverage[toml]==7.9.0
+coverage[toml]==7.10.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-token-utils
     #   pyjwt
     #   secretstorage
     #   social-auth-core
 ddt==1.7.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
 dill==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   virtualenv
 django==4.2.23
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-appconf
     #   django-config-models
     #   django-cors-headers
@@ -171,65 +171,65 @@ django==4.2.23
     #   social-auth-app-django
 django-appconf==1.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-statici18n
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-cors-headers==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-toggles
 django-dynamic-fixture==4.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-extensions==4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-rest-swagger==2.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-django-simple-history==3.8.0
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+django-simple-history==3.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 django-statici18n==2.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-rest-swagger
     #   drf-jwt
@@ -238,46 +238,47 @@ djangorestframework==3.16.0
     #   edx-drf-extensions
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pymongo
-docutils==0.21.2
+docutils==0.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   readme-renderer
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-edx-auth-backends==4.5.0
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-auth-backends==4.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   openedx-events
 edx-django-release-util==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-config-models
+    #   edx-auth-backends
     #   edx-drf-extensions
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -286,24 +287,24 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-drf-extensions==10.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-event-bus-kafka==6.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-event-bus-redis==0.6.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-lint==5.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   lti-consumer-xblock
@@ -311,216 +312,212 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
 edx-rest-api-client==6.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-edx-toggles==5.3.0
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   edx-auth-backends
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 edx-token-utils==0.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 factory-boy==3.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-faker==37.4.0
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+faker==37.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   openedx-events
 filelock==3.18.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
     #   virtualenv
-freezegun==1.5.2
+freezegun==1.5.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 fs==2.4.16
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
 fs-s3fs==1.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   openedx-django-pyfs
-future==1.0.0
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   pyjwkest
 id==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   requests
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
 itypes==1.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   coreapi
 jaraco-classes==3.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 jeepney==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
     #   secretstorage
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 keyring==25.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 lazy==1.6
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-lti-consumer-xblock==9.14.0
+lti-consumer-xblock==9.14.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-lxml==5.4.0
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+lxml==6.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 mako==1.3.10
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   xblock
 markdown-it-py==3.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   rich
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   jinja2
     #   mako
     #   xblock
 mccabe==0.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   markdown-it-py
 mock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 more-itertools==10.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   jaraco-classes
     #   jaraco-functools
 mysqlclient==2.2.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-nh3==0.2.21
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+nh3==0.3.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   readme-renderer
-oauthlib==3.2.2
+oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
     #   requests-oauthlib
     #   social-auth-core
 openapi-codec==1.3.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
 openedx-django-pyfs==3.8.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-openedx-events==10.2.1
+openedx-events==10.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
 openedx-filters==2.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   pyproject-api
     #   pytest
@@ -528,58 +525,53 @@ packaging==25.0
     #   twine
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   stevedore
 platformdirs==4.3.8
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest
+    #   pytest-cov
     #   tox
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.13.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+pycodestyle==2.14.0
+    # via -r requirements/quality.txt
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   cffi
 pycryptodomex==3.23.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
-    #   pyjwkest
 pydocstyle==6.3.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-pygments==2.19.1
+    # via -r requirements/quality.txt
+pygments==2.19.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest
     #   readme-renderer
     #   rich
-pyjwkest==1.4.2
-    # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-    #   lti-consumer-xblock
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   drf-jwt
     #   edx-auth-backends
     #   edx-drf-extensions
@@ -589,88 +581,88 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pylint==3.3.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
 pymemcache==4.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
-pymongo==4.13.1
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+pymongo==4.14.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-api==1.9.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
-pytest==8.4.0
+pytest==8.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.2.0
+pytest-cov==6.2.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 pytest-django==4.11.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   botocore
     #   freezegun
     #   xblock
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   code-annotations
 python3-openid==3.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   xblock
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
     #   edx-django-release-util
@@ -678,22 +670,21 @@ pyyaml==6.0.2
     #   xblock
 readme-renderer==44.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
-redis==6.2.0
+redis==6.4.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   walrus
 requests==2.32.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   id
-    #   pyjwkest
     #   requests-oauthlib
     #   requests-toolbelt
     #   responses
@@ -701,153 +692,152 @@ requests==2.32.4
     #   twine
 requests-oauthlib==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   social-auth-core
 requests-toolbelt==1.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
 responses==0.25.7
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 rfc3986==2.0.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
-rich==14.0.0
+rich==14.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   twine
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   boto3
 secretstorage==3.3.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   keyring
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django-rest-swagger
     #   xblock
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   edx-ccx-keys
     #   edx-django-release-util
     #   edx-lint
     #   fs
     #   fs-s3fs
-    #   pyjwkest
     #   python-dateutil
 snowballstemmer==3.0.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
+    #   -r requirements/quality.txt
     #   pydocstyle
 social-auth-app-django==5.4.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.6.1
+social-auth-core==4.7.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   python-slugify
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   pylint
-tox==4.26.0
+tox==4.28.4
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
 twine==6.1.0
-    # via -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-typing-extensions==4.14.0
+    # via -r requirements/quality.txt
+typing-extensions==4.14.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   faker
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   botocore
     #   requests
     #   responses
     #   twine
-virtualenv==20.31.2
+virtualenv==20.33.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   tox
-walrus==0.9.4
+walrus==0.9.5
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   edx-event-bus-redis
 web-fragments==3.1.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   xblock
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   bleach
 webob==1.8.9
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   xblock
 xblock==5.2.0
     # via
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/quality.txt
-    #   -r /home/runner/work/edx-exams/edx-exams/requirements/test.txt
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
     #   lti-consumer-xblock
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# Description

fix xblock-lti-consumer is bringing pyjwkest as a dependency

# Jira Link 

https://2u-internal.atlassian.net/browse/BOMS-89